### PR TITLE
Refine GUI scale for better vertical fit

### DIFF
--- a/tauri-gui/src-tauri/tauri.conf.json
+++ b/tauri-gui/src-tauri/tauri.conf.json
@@ -13,8 +13,10 @@
     "windows": [
       {
         "title": "tauri-gui",
-        "width": 800,
-        "height": 600
+        "width": 1280,
+        "height": 900,
+        "minWidth": 1120,
+        "minHeight": 820
       }
     ],
     "security": {

--- a/tauri-gui/src-tauri/tauri.conf.json
+++ b/tauri-gui/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
       {
         "title": "tauri-gui",
         "width": 1280,
-        "height": 900,
+        "height": 1200,
         "minWidth": 1120,
         "minHeight": 820
       }

--- a/tauri-gui/src/App.css
+++ b/tauri-gui/src/App.css
@@ -1,7 +1,7 @@
 :root {
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
     "Helvetica Neue", sans-serif;
-  font-size: 16px;
+  font-size: 15px;
   line-height: 1.5;
   font-weight: 400;
   color: #0f172a;
@@ -22,12 +22,12 @@ html {
 .app-shell main {
   max-width: 1080px;
   margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
+  padding: 2.5rem 1.25rem 3.25rem;
 }
 
 .page-header h1 {
   margin: 0;
-  font-size: 2.25rem;
+  font-size: 2rem;
   font-weight: 700;
   color: #0f172a;
 }
@@ -40,45 +40,45 @@ html {
 }
 
 .matching-form {
-  margin-top: 2.5rem;
+  margin-top: 2rem;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.5rem;
 }
 
 fieldset {
   border-radius: 16px;
   border: 1px solid #cbd5f5;
-  padding: 1.75rem;
+  padding: 1.5rem;
   background: #ffffff;
   box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
 }
 
 legend {
   font-weight: 600;
-  font-size: 1.05rem;
-  padding: 0 0.75rem;
+  font-size: 1rem;
+  padding: 0 0.65rem;
 }
 
 .section-description {
   margin-top: 0.25rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
   color: #475569;
 }
 
 .radio-group {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .radio-option {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.45rem;
   border-radius: 12px;
   border: 1px solid transparent;
-  padding: 0.65rem 1rem;
+  padding: 0.55rem 0.95rem;
   background: #f8fafc;
   cursor: pointer;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -96,8 +96,8 @@ legend {
 .input-stack {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  margin-top: 1.25rem;
+  gap: 0.75rem;
+  margin-top: 1rem;
 }
 
 .input-stack label {
@@ -109,10 +109,10 @@ textarea,
 input[type="text"],
 input[type="number"] {
   width: 100%;
-  padding: 0.7rem 0.9rem;
+  padding: 0.6rem 0.85rem;
   border-radius: 10px;
   border: 1px solid #cbd5f5;
-  font-size: 1rem;
+  font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
   background: #ffffff;
   color: #0f172a;
@@ -134,8 +134,8 @@ textarea {
 .button-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 1.25rem;
+  gap: 0.85rem;
+  margin-top: 1rem;
 }
 
 .button-row.inline {
@@ -146,8 +146,8 @@ textarea {
 button {
   border: none;
   border-radius: 999px;
-  padding: 0.85rem 1.75rem;
-  font-size: 1rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
   background: #2563eb;
@@ -200,15 +200,15 @@ button.add-entry-button:not(:disabled):hover {
 .small-note {
   margin: 0;
   color: #64748b;
-  font-size: 0.875rem;
+  font-size: 0.825rem;
 }
 
 .checkbox-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-top: 1.25rem;
-  padding: 0.85rem 1rem;
+  gap: 0.65rem;
+  margin-top: 1.1rem;
+  padding: 0.75rem 0.9rem;
   border-radius: 12px;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
@@ -223,13 +223,13 @@ button.add-entry-button:not(:disabled):hover {
 .number-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
+  gap: 0.85rem;
   align-items: start;
 }
 
 .status-banner {
-  margin-top: 1.75rem;
-  padding: 1rem 1.25rem;
+  margin-top: 1.5rem;
+  padding: 0.85rem 1.15rem;
   border-radius: 12px;
   font-weight: 500;
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
@@ -254,8 +254,8 @@ button.add-entry-button:not(:disabled):hover {
 }
 
 .result-card {
-  margin-top: 2.5rem;
-  padding: 1.75rem;
+  margin-top: 2rem;
+  padding: 1.5rem;
   border-radius: 18px;
   background: #ffffff;
   border: 1px solid #e2e8f0;
@@ -274,14 +274,14 @@ button.add-entry-button:not(:disabled):hover {
 }
 
 .detail-grid {
-  margin-top: 1.5rem;
+  margin-top: 1.35rem;
   display: grid;
-  gap: 1.25rem;
+  gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .detail-card {
-  padding: 1.1rem 1.2rem;
+  padding: 0.95rem 1.05rem;
   border-radius: 14px;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
@@ -289,8 +289,8 @@ button.add-entry-button:not(:disabled):hover {
 
 .detail-card h3 {
   margin-top: 0;
-  margin-bottom: 0.65rem;
-  font-size: 1.05rem;
+  margin-bottom: 0.55rem;
+  font-size: 1rem;
 }
 
 .detail-card dl {
@@ -319,7 +319,7 @@ button.add-entry-button:not(:disabled):hover {
 
 .path-list li {
   word-break: break-all;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .prompt-preview {
@@ -343,10 +343,10 @@ button.add-entry-button:not(:disabled):hover {
 
 .faculty-table th,
 .faculty-table td {
-  padding: 0.65rem 0.85rem;
+  padding: 0.55rem 0.75rem;
   border-bottom: 1px solid #cbd5f5;
   text-align: left;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .faculty-table tbody tr:last-child td {
@@ -371,7 +371,7 @@ button.add-entry-button:not(:disabled):hover {
 .faculty-entry-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.85rem;
+  gap: 0.75rem;
   align-items: center;
 }
 


### PR DESCRIPTION
## Summary
- reduce the base font size and tighten header sizing so the app content scales slightly smaller
- decrease spacing, padding, and control sizing throughout the form to fit more of the UI vertically without scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc79c0cba083258b3bce79b4856531