### PR TITLE
Add faculty dataset management and preview

### DIFF
--- a/tauri-gui/src-tauri/Cargo.toml
+++ b/tauri-gui/src-tauri/Cargo.toml
@@ -25,4 +25,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 csv = "1"
 calamine = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 

--- a/tauri-gui/src-tauri/assets/default_faculty_dataset.tsv
+++ b/tauri-gui/src-tauri/assets/default_faculty_dataset.tsv
@@ -1,0 +1,6 @@
+faculty_id	name	program	research_interests
+F001	Dr. Ada Lovelace	Computational and Systems Biology	Computational biology; algorithm design for biological systems
+F002	Dr. Marie Curie	Cancer Biology	Radiation oncology; translational cancer research
+F003	Dr. George Washington Carver	Plant & Microbial Biosciences	Plant sciences; microbial interactions in agriculture
+F004	Dr. Chien-Shiung Wu	Immunology	Immune signaling pathways; cellular immunotherapy
+F005	Dr. Rosalind Franklin	Molecular Genetics and Genomics	Structural genomics; nucleic acid imaging

--- a/tauri-gui/src-tauri/assets/default_faculty_dataset.tsv
+++ b/tauri-gui/src-tauri/assets/default_faculty_dataset.tsv
@@ -1,6 +1,613 @@
-faculty_id	name	program	research_interests
-F001	Dr. Ada Lovelace	Computational and Systems Biology	Computational biology; algorithm design for biological systems
-F002	Dr. Marie Curie	Cancer Biology	Radiation oncology; translational cancer research
-F003	Dr. George Washington Carver	Plant & Microbial Biosciences	Plant sciences; microbial interactions in agriculture
-F004	Dr. Chien-Shiung Wu	Immunology	Immune signaling pathways; cellular immunotherapy
-F005	Dr. Rosalind Franklin	Molecular Genetics and Genomics	Structural genomics; nucleic acid imaging
+Employee ID	Name	Program 1	Program 2	Program 3	Program 4
+379589	"Abraham, Joanna"	Biomedical Informatics and Data Science			
+70380	"Abu-Amer, Yousef"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+308648	"Abumrad, Nada"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+503796	"Ackerman, Sarah"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+308292	"Agrawal, Arpana"	Human and Statistical Genetics			
+10986	"Akk, Gustav"	Molecular Cell Biology	Neurosciences		
+370946	"Albrecht, Matthew"	"Evolution, Ecology and Population Biology"			
+113580	"Alexander-Brett, Jennifer"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	
+339481	"Al-Hasani McCall, Ream"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+505530	"Almeida de Pinho Ribeiro, Felipe"	Immunology	Molecular Microbiology and Microbial Pathogenesis	Neurosciences	
+343164	"Amarasinghe, Gaya"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+519079	"Amargant i Riera, Farners"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+6934	"An, Hongyu"	Neurosciences			
+326328	"Ances, Beau"	Biomedical Informatics and Data Science	Molecular Microbiology and Microbial Pathogenesis	Neurosciences	
+302388	"Apte, Rajendra"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences		
+344508	"Artomov, Maksym"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Immunology	
+390654	"Ashrafi, Ghazal"	Molecular Cell Biology	Neurosciences		
+96372	"Atkinson, John"	Human and Statistical Genetics	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+83942	"Avidan, Michael"	Neurosciences			
+67415	"Baldridge, Dustin"	Biomedical Informatics and Data Science	Molecular Genetics and Genomics		
+339804	"Baldridge, Megan"	Computational and Systems Biology	Immunology	Molecular Genetics and Genomics	
+361390	"Bambouskova, Monika"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Cell Biology	
+43014	"Baranski, Thomas"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+307828	"Barbour, Dennis"	Biomedical Informatics and Data Science	Neurosciences		
+79912	"Barch, Deanna"	Neurosciences			
+393381	"Bark, David"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+102488	"Barnes, Wayne"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Genetics and Genomics	Plant and Microbial Biosciences	
+356006	"Bart, Rebecca"	Molecular Microbiology and Microbial Pathogenesis	Plant and Microbial Biosciences		
+18589	"Bassnett, Steven"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+62259	"Bateman, Randall"	Biomedical Informatics and Data Science	Neurosciences		
+352481	"Batista, Luis"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+347942	"Baxter, Ivan"	Computational and Systems Biology	Plant and Microbial Biosciences		
+10974	"Bayly, Philip"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+305311	"Bednarski, Jeffrey"	Immunology	Molecular Cell Biology	Molecular Genetics and Genomics	
+515947	"Belloy, Michael"	Biomedical Informatics and Data Science	Computational and Systems Biology	Molecular Genetics and Genomics	
+326948	"Ben-Shahar, Yehuda"	Biomedical Informatics and Data Science	"Evolution, Ecology and Population Biology"	Molecular Genetics and Genomics	
+69476	"Benzinger, Tammie"	Biomedical Informatics and Data Science	Neurosciences		
+305047	"Berezin, Mikhail"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science		
+393968	"Bergom, Carmen"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+105683	"Bernal-Mizrachi, Carlos"	Molecular Cell Biology			
+392637	"Bersi, Matthew"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Cell Biology	
+101317	"Beverley, Stephen"	Immunology	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+32076	"Bierut, Laura"	Biomedical Informatics and Data Science	Human and Statistical Genetics		
+383266	"Bijsterbosch, Janine"	Biomedical Informatics and Data Science	Computational and Systems Biology	Neurosciences	
+20843	"Black, Kevin"	Biomedical Informatics and Data Science	Neurosciences		
+95869	"Blumer, Kendall"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+343521	"Bogdan, Ryan"	Human and Statistical Genetics	Molecular Genetics and Genomics	Neurosciences	
+102357	"Boime, Irving"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+395205	"Bolton, Kelly"	Cancer Biology	Computational and Systems Biology	Human and Statistical Genetics	
+339189	"Boon, Jacco"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+356670	"Bose, Arpita"	Computational and Systems Biology	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+10565	"Bose, Ron"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+346072	"Bradley, Alexander"	"Evolution, Ecology and Population Biology"	Plant and Microbial Biosciences		
+98702	"Braver, Todd"	Neurosciences			
+41132	"Brent, Michael"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+11716	"Brent, Tamara"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+52938	"Brett, Thomas"	"Biochemistry, Biophysics, and Structural Biology"	Immunology		
+41812	"Brody, Steven"	Molecular Cell Biology			
+301934	"Brookheart, Rita"	Molecular Cell Biology			
+350310	"Brossier, Nicole"	Cancer Biology			
+395251	"Brunner, Peter"	Neurosciences			
+29004	"Bubeck-Wardenburg, Juliane"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+51334	"Buhler, Jeremy"	Computational and Systems Biology	Molecular Genetics and Genomics		
+101185	"Burgers, Peter"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+103167	"Burkhalter, Andreas"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences		
+7709	"Burton, Harold"	Neurosciences			
+314063	"Campbell, Meghan"	Neurosciences			
+373865	"Cao, Yin"	Biomedical Informatics and Data Science	Cancer Biology	Computational and Systems Biology	
+318285	"Cao, Yu-Qing"	Neurosciences			
+40842	"Caparon, Michael"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+326946	"Carlson, Bruce"	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	Neurosciences	
+322215	"Carter, Alexandre"	Neurosciences			
+501145	"Castro, Daniel"	Computational and Systems Biology	Molecular Genetics and Genomics	Neurosciences	
+318660	"Cavalli, Valeria"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+358315	"Chakrabartty, Shantanu"	Computational and Systems Biology	Neurosciences		
+100709	"Chalker, Douglas"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+342544	"Challen, Grant"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+391998	"Chanda, Baron"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+332657	"Chang, Su-Hsin"	Biomedical Informatics and Data Science	Computational and Systems Biology		
+379047	"Chaudhuri, Aadel"	Cancer Biology	Computational and Systems Biology	Human and Statistical Genetics	
+390876	"Che, Tao"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+303494	"Chen, David"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	
+115831	"Chen, Feng"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"		
+511551	"Chen, Haobin"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+361209	"Chen, Hong"	Cancer Biology	Molecular Cell Biology	Neurosciences	
+111705	"Chen, Li-Shiun"	Biomedical Informatics and Data Science			
+322332	"Chen, Maggie"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+9535	"Chen, Shiming"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+380131	"Chen, Yao"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+311641	"Cheng, Wayland"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+359302	"Chheda, Milan"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Immunology	
+348013	"Ching, Shinung"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+394136	"Cho, Jaehyung"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Cell Biology	
+317692	"Choi, Jaebok"	Cancer Biology	Immunology	Molecular Cell Biology	
+31044	"Choi, Kyunghee"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Immunology	
+74574	"Christopher, Matthew"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+311351	"Ciorba, Matthew"	Cancer Biology	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+311237	"Cirrito, John"	Neurosciences			
+80397	"Civitelli, Roberto"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+378287	"Clark, Brian"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+88695	"Clemens, Regina"	Immunology	Molecular Cell Biology		
+114156	"Cohen, Barak"	Computational and Systems Biology	Molecular Genetics and Genomics		
+319813	"Colditz, Graham"	Biomedical Informatics and Data Science	Cancer Biology	Molecular Genetics and Genomics	
+4973	"Cole, Sessions"	"Developmental, Regenerative and Stem Cell Biology"	Human and Statistical Genetics		
+4743	"Colonna, Marco"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+378802	"Cooper, Jonathan"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+308523	"Cooper, Megan"	Human and Statistical Genetics	Immunology		
+349363	"Copits, Bryan"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	
+312674	"Corbo, Joseph"	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	
+384765	"Cote, Richard"	Cancer Biology	Immunology		
+18406	"Covey, Douglas"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+381841	"Creed, Meaghan"	Neurosciences			
+10952	"Cresci, Sharon"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+400261	"Crewe, Clair"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+99586	"Crouch, Erika"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+321253	"Cruchaga, Carlos"	Biomedical Informatics and Data Science	Human and Statistical Genetics	Molecular Genetics and Genomics	
+307100	"Cui, Jianmin"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+304845	"Culver, Joseph"	Neurosciences			
+336468	"Curiel, David"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Genetics and Genomics	
+525381	"Dai, Zhiyu"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+330765	"Dantas, Gautam"	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	Molecular Genetics and Genomics	
+7128	"Davidson, Nicholas"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Molecular Cell Biology	
+104817	"Davila-Roman, Victor"	Molecular Genetics and Genomics			
+347910	"Davis, Gus"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Cell Biology	
+111586	"DeBosch, Brian"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+364797	"Dell, Anthony"	"Evolution, Ecology and Population Biology"			
+338687	"DeNardo, David"	Cancer Biology	Immunology	Molecular Cell Biology	
+313179	"DeSelm, Carl"	Cancer Biology	Immunology	Molecular Cell Biology	
+387062	"Di Paola, Jorge"	Molecular Cell Biology	Molecular Genetics and Genomics		
+7335	"Diamond, Michael"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+87637	"DiAntonio, Aaron"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences		
+392283	"Dietmann, Sabine"	Biomedical Informatics and Data Science			
+118971	"Ding, Li"	Cancer Biology	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	
+386135	"Ding, Siyuan"	Immunology	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+325858	"Diwan, Abhinav"	Molecular Cell Biology			
+325821	"Dixit, Ramanand"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Plant and Microbial Biosciences	
+348555	"Djuranovic, Sergej"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+322800	"Dobbins, Ian"	Neurosciences			
+324929	"Dorn, Gerald"	Human and Statistical Genetics	Molecular Cell Biology	Molecular Genetics and Genomics	
+303104	"Dosenbach, Nico"	Neurosciences			
+336761	"Dougherty, Joseph"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+331965	"Drake, Bettina"	Cancer Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+97918	"Dutcher, Susan"	Human and Statistical Genetics	Molecular Cell Biology	Molecular Genetics and Genomics	
+15764	"Earhart, Gammon"	Neurosciences			
+111431	"Edelson, Brian"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+359649	"Edwards, Christine"	"Evolution, Ecology and Population Biology"	Plant and Microbial Biosciences		
+333194	"Edwards, John"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+334151	"Egawa, Takeshi"	"Developmental, Regenerative and Stem Cell Biology"	Immunology		
+510878	"Egervari, Gabor"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+301485	"Eggebrecht, Adam"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+382293	"Elgendy, Bahaa Eldien"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology		
+371474	"Ellebedy, Ali"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+73331	"Elson, Elliot"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+340290	"England, Sarah"	Molecular Cell Biology			
+10925	"Evers, Alex"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+302399	"Faccio, Roberta"	Cancer Biology	Immunology	Molecular Cell Biology	
+308047	"Fehniger, Todd"	Cancer Biology	Immunology		
+358125	"Feldman, Mario"	Molecular Microbiology and Microbial Pathogenesis	Plant and Microbial Biosciences		
+24388	"Ferguson, Thomas"	Immunology	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+366493	"Ferraro, Francesca"	Cancer Biology	Immunology	Molecular Cell Biology	
+322058	"Fike, David"	"Evolution, Ecology and Population Biology"	Plant and Microbial Biosciences		
+300299	"Finck, Brian"	Molecular Cell Biology			
+310834	"Fischer, Peter"	"Evolution, Ecology and Population Biology"	Molecular Microbiology and Microbial Pathogenesis		
+342822	"Fleckenstein, James"	Molecular Microbiology and Microbial Pathogenesis	Plant and Microbial Biosciences		
+372243	"Foraker, Randi"	Biomedical Informatics and Data Science			
+388651	"Foutz, Tom"	Computational and Systems Biology	Neurosciences		
+509482	"Franken, Tom"	Neurosciences			
+76354	"Fraser, Vicky"	"Evolution, Ecology and Population Biology"			
+24136	"Fremont, Daved"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+302520	"French, Anthony"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+307861	"Fritz, Stephanie"	Human and Statistical Genetics	Molecular Microbiology and Microbial Pathogenesis		
+91735	"Frolova, Antonina"	Molecular Cell Biology			
+360304	"Gabel, Harrison"	Molecular Cell Biology	Molecular Genetics and Genomics	Neurosciences	
+328367	"Galburt, Eric"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Microbiology and Microbial Pathogenesis		
+349112	"Gallardo, Gilbert"	Molecular Cell Biology	Neurosciences		
+323499	"Galletto, Roberto"	"Biochemistry, Biophysics, and Structural Biology"			
+397411	"Garcia, Benjamin"	"Biochemistry, Biophysics, and Structural Biology"			
+501149	"Gastounioti, Aimilia"	Biomedical Informatics and Data Science	Cancer Biology		
+336677	"Geisler, Stefanie"	Neurosciences			
+104983	"Genin, Guy"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Plant and Microbial Biosciences	
+305644	"Gereau, Robert"	Molecular Cell Biology	Neurosciences		
+501747	"Gewin, Leslie"	Molecular Cell Biology			
+329986	"Gilbert, Nicole"	Molecular Microbiology and Microbial Pathogenesis			
+19660	"Gillanders, Will"	Cancer Biology	Immunology		
+326855	"Glasser, Matthew"	Biomedical Informatics and Data Science	Neurosciences		
+39076	"Goldberg, Daniel"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+387774	"Goldfarb, Dennis"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Computational and Systems Biology	
+7274	"Goldsmith, Matthew"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics		
+346801	"Gomez, Felicia"	Biomedical Informatics and Data Science	Cancer Biology	Molecular Genetics and Genomics	
+518862	"Gomez-Lopez, Nardhy"	Computational and Systems Biology	Immunology	Molecular Cell Biology	
+335099	"Gonzalez-Perez, Vivian"	Molecular Cell Biology	Neurosciences		
+393706	"Goodhill, Geoffrey"	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences	
+388842	"Goodwin, Matthew"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+337146	"Gordon, Brian"	Biomedical Informatics and Data Science	Neurosciences		
+348748	"Gordon, Evan"	Neurosciences			
+6037	"Gordon, Jeffrey"	Computational and Systems Biology	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+323917	"Goyal, Manu"	Neurosciences			
+53496	"Grant, Gregory"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+385021	"Green, Abby"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+361070	"Greenberg, Michael"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+513083	"Greer, Eric"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+339530	"Griffith, Malachi"	Biomedical Informatics and Data Science	Cancer Biology	Computational and Systems Biology	
+344686	"Griffith, Obi"	Biomedical Informatics and Data Science	Cancer Biology	Immunology	
+52441	"Gross, Michael"	"Biochemistry, Biophysics, and Structural Biology"			
+12244	"Gross, Richard"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+78147	"Gu, Charles"	Biomedical Informatics and Data Science	Computational and Systems Biology	Human and Statistical Genetics	
+361436	"Guilak, Farshid"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Cell Biology	
+302998	"Gurnett, Christina"	Molecular Genetics and Genomics			
+23339	"Gutmann, David"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	
+332345	"Halabi, Carmen"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+52997	"Hall, Kathleen"	"Biochemistry, Biophysics, and Structural Biology"			
+330621	"Hallahan, Dennis"	Cancer Biology	Molecular Cell Biology		
+327534	"Haller, Gabriel"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+523062	"Han, Claudia"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Genetics and Genomics	
+355126	"Han, Edward"	Neurosciences			
+356164	"Han, Martha"	Neurosciences			
+71978	"Handley, Scott"	Computational and Systems Biology	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+516242	"Harbison, Richard"	Computational and Systems Biology	Immunology		
+354150	"Haroutounian, Simon"	Neurosciences			
+389018	"Hart, Robert"	"Evolution, Ecology and Population Biology"			
+356544	"Haspel, Jeffrey"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+46208	"Head, Denise"	Neurosciences			
+19591	"Heath, Andrew"	Biomedical Informatics and Data Science	"Evolution, Ecology and Population Biology"	Human and Statistical Genetics	
+508929	"Heemstra, Jennifer"	"Biochemistry, Biophysics, and Structural Biology"			
+349759	"Held, Jason"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Cancer Biology	
+52098	"Henderson, Jeffrey"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Microbiology and Microbial Pathogenesis		
+368266	"Hengen, Keith"	Computational and Systems Biology	Molecular Cell Biology	Neurosciences	
+364507	"Herrlich, Andreas"	Molecular Cell Biology			
+15464	"Hershey, Tamara"	Neurosciences			
+43557	"Herzog, Erik"	Biomedical Informatics and Data Science	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+113097	"Hirbe, Angela"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+324918	"Hirose, Keiko"	Neurosciences			
+346669	"Holehouse, Alex"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Cell Biology	
+60608	"Holtzman, David"	Molecular Cell Biology	Neurosciences		
+81543	"Holtzman, Michael"	Immunology	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+110229	"Holy, Timothy"	Computational and Systems Biology	Neurosciences		
+334611	"Horani, Amjad"	Molecular Cell Biology			
+331437	"Housten, Ashley"	Biomedical Informatics and Data Science	Molecular Genetics and Genomics		
+43046	"Hruz, Paul"	Molecular Cell Biology			
+30482	"Hsieh, Chyi"	Cancer Biology	Immunology		
+393435	"Hu, Feng Sheng"	"Evolution, Ecology and Population Biology"	Plant and Microbial Biosciences		
+513671	"Huang, Cheng"	Computational and Systems Biology	Molecular Cell Biology	Neurosciences	
+102203	"Huang, Henry"	Molecular Microbiology and Microbial Pathogenesis			
+15249	"Huettner, James"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+65086	"Hughes, Jing"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+27385	"Hultgren, Scott"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+359422	"Humphreys, Benjamin"	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"		
+300396	"Hunstad, David"	Molecular Microbiology and Microbial Pathogenesis			
+361185	"Ibanez, Laura"	Molecular Genetics and Genomics			
+4675	"Imai, Shin-Ichiro"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+523061	"Inoue, Masatoshi"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+113914	"Ippolito, Joseph"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+371737	"Jackrel, Meredith"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+101743	"Jain, Sanjay"	Biomedical Informatics and Data Science	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	
+323491	"James, Aimee"	Human and Statistical Genetics	Molecular Genetics and Genomics		
+329631	"Janetka, Jim"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+350160	"Janowski, Andrew"	Molecular Microbiology and Microbial Pathogenesis			
+373640	"Jansen, Silvia"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+364117	"Javaheri, Ali"	Molecular Cell Biology	Molecular Genetics and Genomics		
+318620	"Jez, Joseph"	"Biochemistry, Biophysics, and Structural Biology"	Plant and Microbial Biosciences		
+386252	"Jiang, Joy"	Biomedical Informatics and Data Science	Cancer Biology		
+336969	"Jin, Peter"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+360970	"Johanns, Tanner"	Cancer Biology	Immunology		
+373804	"Johnson, Aaron"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Cell Biology	
+313536	"Ju, Tao"	"Biochemistry, Biophysics, and Structural Biology"			
+503230	"Kang, Yoon A"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Immunology	
+381081	"Kannampallil, Thomas"	Biomedical Informatics and Data Science			
+352664	"Kapoor, Vaishali"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Immunology	
+331079	"Karch, Celeste"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Neurosciences	
+373808	"Kast, David"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+45516	"Kau, Andrew"	Computational and Systems Biology	Immunology	Molecular Genetics and Genomics	
+38390	"Kaufman, Charles"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+364508	"Kefalogianni, Eirini"	Immunology	Molecular Cell Biology		
+355972	"Kellogg, Elizabeth"	"Evolution, Ecology and Population Biology"	Molecular Genetics and Genomics	Plant and Microbial Biosciences	
+388320	"Kendall, Peggy"	Immunology			
+387095	"Kepecs, Adam"	Neurosciences			
+311040	"Kerschensteiner, Daniel"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Neurosciences	
+392389	"Khabele, Dineo"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+14225	"Kim, Albert"	Cancer Biology	Computational and Systems Biology	Molecular Genetics and Genomics	
+322526	"Kim, Alfred"	Immunology			
+383752	"Kim, Jae-Sung"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+518460	"Kim, Jinkyung"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+371873	"Kim, Miriam"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Immunology	
+391645	"Kipnis, Jonathan"	Immunology	Molecular Cell Biology	Molecular Genetics and Genomics	
+337876	"Klechevsky, Eynav"	Cancer Biology	Computational and Systems Biology	Immunology	
+328254	"Klyachko, Vitaly"	Neurosciences			
+66586	"Kornfeld, S. Kerry"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+43377	"Kornfeld, Stuart"	Molecular Cell Biology			
+25834	"Kotzbauer, Paul"	Molecular Cell Biology	Neurosciences		
+9845	"Kovacs, Sandor"	"Biochemistry, Biophysics, and Structural Biology"			
+35142	"Kranz, Robert"	Molecular Microbiology and Microbial Pathogenesis	Plant and Microbial Biosciences		
+384477	"Kravitz, Alexxai"	Neurosciences			
+310603	"Kress, Geraldine"	Neurosciences			
+42524	"Kroll, Kristen"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Neurosciences	
+352634	"Kulkarni, Devesha"	Biomedical Informatics and Data Science	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+350983	"Kulkarni, Hrishikesh"	Biomedical Informatics and Data Science	Immunology	Molecular Cell Biology	
+52658	"Kummer, Terrance"	Neurosciences			
+100724	"Kunkel, Barbara"	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	Plant and Microbial Biosciences	
+358386	"Kutluay, Sebla"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Microbiology and Microbial Pathogenesis	
+349641	"Kwon, Jennie"	Molecular Microbiology and Microbial Pathogenesis			
+336330	"Kyei, George"	Molecular Microbiology and Microbial Pathogenesis			
+367539	"Lai, Albert"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Computational and Systems Biology	
+393319	"Laidlaw, Brian"	Computational and Systems Biology	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+381888	"Landis, Michael"	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	Molecular Genetics and Genomics	
+356306	"Landsness, Eric"	Neurosciences			
+3183	"Lang, Catherine"	Neurosciences			
+3057	"Lanza, Gregory"	"Biochemistry, Biophysics, and Structural Biology"			
+111587	"Lavine, Kory"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Cell Biology	
+326466	"Lawson, Heather"	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	Human and Statistical Genetics	
+104359	"Lee, Jin-Moo"	Neurosciences			
+305486	"Lenschow, Deborah"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+509420	"LeRoux, Michele"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+343166	"Leung, Daisy"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Microbiology and Microbial Pathogenesis		
+23179	"Leuthardt, Eric"	Neurosciences			
+4036	"Levin, Petra"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+360594	"Lew, Matthew"	"Biochemistry, Biophysics, and Structural Biology"			
+53886	"Ley, Timothy"	Cancer Biology	Immunology	Molecular Genetics and Genomics	
+378259	"Li, Fuhai"	Biomedical Informatics and Data Science	Cancer Biology	Computational and Systems Biology	
+318687	"Li, Jr-Shin"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Computational and Systems Biology	
+389330	"Li, Qingyun"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+338764	"Li, Weikai"	"Biochemistry, Biophysics, and Structural Biology"			
+398293	"Li, Xiaowei"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences	
+518056	"Li, Yang"	Biomedical Informatics and Data Science	Cancer Biology	Computational and Systems Biology	
+350324	"Lim, Kian-Huat"	Cancer Biology	Immunology	Molecular Cell Biology	
+380364	"Ling, Fangqiong"	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	Molecular Microbiology and Microbial Pathogenesis	
+34861	"Lingle, Christopher"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+43925	"Link, Daniel"	Cancer Biology	Immunology	Molecular Cell Biology	
+509404	"Lishko, Polina"	Molecular Cell Biology			
+374695	"Liu, Lei"	Biomedical Informatics and Data Science			
+343642	"Liu, Qin"	Molecular Cell Biology	Neurosciences		
+346443	"Liu, Ta-Chiang"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+322461	"Lodhi, Irfan"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+9108	"Lohman, Timothy"	"Biochemistry, Biophysics, and Structural Biology"			
+3725	"Longmore, Gregory"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Immunology	
+391450	"Lopez, Carolina"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+317140	"Losos, Jonathan"	"Evolution, Ecology and Population Biology"			
+312786	"Lucey, Brendan"	Neurosciences			
+307753	"Ma, Liang"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+18739	"Mackinnon, Susan"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences		
+43572	"Magee, Jeffrey"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+381244	"Mahajan, Nupam"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+341866	"Maher, Christopher"	Cancer Biology	Computational and Systems Biology	Human and Statistical Genetics	
+346420	"Mahjoub, Moe"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+387720	"Major, Ben"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Computational and Systems Biology	
+377878	"Majumdar, Susruta"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+315406	"Marcus, Daniel"	Biomedical Informatics and Data Science	Cancer Biology	Neurosciences	
+353249	"Margolis, Todd"	Molecular Microbiology and Microbial Pathogenesis			
+341098	"Markovina, Stephanie"	Cancer Biology	Molecular Cell Biology		
+517862	"Mathios, Dimitrios"	Biomedical Informatics and Data Science	Computational and Systems Biology	Molecular Genetics and Genomics	
+510524	"Mavers, Melissa"	Cancer Biology	Immunology	Molecular Cell Biology	
+116472	"Mbalaviele, Gabriel"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+75757	"McAlinden, Audrey"	"Developmental, Regenerative and Stem Cell Biology"			
+336862	"McCall, Jordan"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+101635	"McCarthy, John"	Neurosciences			
+116630	"McCoy, William"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+20975	"McDermott, Kathleen"	Neurosciences			
+374188	"McNeill, Helen"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+385568	"McPherson, Jacob"	Neurosciences			
+385570	"McPherson, Laura"	Neurosciences			
+354669	"Meacham, John"	"Biochemistry, Biophysics, and Structural Biology"			
+26459	"Mennerick, Steven"	Molecular Cell Biology	Neurosciences		
+115374	"Meyer, Gretchen"	"Developmental, Regenerative and Stem Cell Biology"			
+368051	"Meyers, Blake"	Computational and Systems Biology	Molecular Genetics and Genomics	Plant and Microbial Biosciences	
+317721	"Micchelli, Craig"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics		
+95661	"Milbrandt, Jeffrey"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+309078	"Miller, Mark"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+61908	"Miller, Timothy"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+361169	"Millman, Jeffrey"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+45471	"Miner, Jeff"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+327379	"Mirica, Liviu"	"Biochemistry, Biophysics, and Structural Biology"			
+300068	"Mitra, Robi"	Computational and Systems Biology	Molecular Genetics and Genomics		
+118794	"Mitreva, Makedonka"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Genetics and Genomics	
+12419	"Moeller, Kevin"	"Biochemistry, Biophysics, and Structural Biology"			
+373827	"Mokalled, Mayssa"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+388829	"Mollah, Shamim"	Biomedical Informatics and Data Science	Cancer Biology	Computational and Systems Biology	
+354644	"Monosov, Ilya"	Neurosciences			
+43797	"Moran, Daniel"	Neurosciences			
+56839	"Morgan, Josh"	"Developmental, Regenerative and Stem Cell Biology"	"Evolution, Ecology and Population Biology"	Neurosciences	
+312178	"Morley, Sharon"	Immunology	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+361007	"Moron-Concepcion, Jose"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+361420	"Morris, Samantha"	Biomedical Informatics and Data Science	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	
+90324	"Morrison, Aubrey"	Molecular Cell Biology			
+344556	"Mosammaparast, Nima"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+373540	"Mudd, Philip"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+312258	"Muegge, Brian"	Computational and Systems Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+374125	"Mukherji, Arindam"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Cell Biology	
+96067	"Murphy, Kenneth"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Cell Biology	
+340857	"Musiek, Erik"	Neurosciences			
+335984	"Myers, Jonathan"	"Evolution, Ecology and Population Biology"			
+314932	"Nehorai, Arye"	Biomedical Informatics and Data Science	Computational and Systems Biology	Neurosciences	
+3515	"Nerbonne, Jeanne"	Molecular Cell Biology	Neurosciences		
+31269	"Newberry, Rodney"	Immunology			
+18368	"Nichols, Colin"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+393574	"Niemi, Natalie"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Cell Biology	
+103534	"Nonet, Michael"	Molecular Genetics and Genomics	Neurosciences		
+317706	"Norris, Aaron"	Neurosciences			
+347872	"Nusinow, Dmitri"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Plant and Microbial Biosciences	
+338370	"Oh, Stephen"	Cancer Biology	Immunology	Molecular Cell Biology	
+356971	"O'Keefe, Regis"	Molecular Cell Biology	Molecular Genetics and Genomics		
+67166	"Olsen, Kenneth"	"Evolution, Ecology and Population Biology"	Plant and Microbial Biosciences		
+507229	"Olson, John"	Cancer Biology	Molecular Cell Biology		
+102261	"O'Malley, Karen"	Molecular Cell Biology	Neurosciences		
+102734	"Ornitz, David"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Neurosciences	
+349472	"Orvedahl, Anthony"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+11577	"Osdoby, Philip"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+505209	"Ozpolat, Busra"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Plant and Microbial Biosciences	
+354426	"Pachynski, Russell"	Cancer Biology	Immunology	Molecular Cell Biology	
+326947	"Padoa-Schioppa, Camillo"	Neurosciences			
+393503	"Pagliarini, Dave"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Cell Biology	
+7337	"Pakrasi, Himadri"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Genetics and Genomics	Plant and Microbial Biosciences	
+113698	"Palanca, Ben"	Neurosciences			
+364961	"Paley, Michael"	Computational and Systems Biology	Immunology	Neurosciences	
+342810	"Pandey, Sona"	Plant and Microbial Biosciences			
+378604	"Papouin, Thomas"	Neurosciences			
+3644	"Pappu, Rohit"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Plant and Microbial Biosciences	
+355098	"Park, Yikyung"	Biomedical Informatics and Data Science	Cancer Biology		
+369543	"Parker, Jonathan"	Immunology	Molecular Cell Biology	Neurosciences	
+348646	"Pathak, Amit"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+310286	"Patti, Gary"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Cancer Biology	
+365696	"Payne, Philip"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Computational and Systems Biology	
+317705	"Payton, Jacqueline"	Biomedical Informatics and Data Science	Cancer Biology	Molecular Genetics and Genomics	
+369944	"Penczykowski, Rachel"	"Evolution, Ecology and Population Biology"	Plant and Microbial Biosciences		
+514317	"Peng, Guangyong"	Cancer Biology	Immunology	Neurosciences	
+385697	"Perlman, Susan"	Neurosciences			
+15564	"Perlmutter, David"	Immunology	Molecular Cell Biology	Molecular Genetics and Genomics	
+79005	"Perlmutter, Joel"	Neurosciences			
+105181	"Pham, Christine"	Immunology	Molecular Genetics and Genomics		
+360284	"Philip, Benjamin"	Neurosciences			
+359360	"Philips, Jennifer"	Immunology	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+391427	"Pignatelli, Marco"	Molecular Cell Biology	Neurosciences		
+12600	"Pike, Linda"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+356476	"Piston, David"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Computational and Systems Biology	
+332874	"Politi, Mary"	Biomedical Informatics and Data Science	Human and Statistical Genetics	Molecular Genetics and Genomics	
+510310	"Pollina, Elizabeth"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+26571	"Ponder, Jay"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology		
+508845	"Pradhan, Amynah"	Molecular Cell Biology	Neurosciences		
+81908	"Province, Michael"	Biomedical Informatics and Data Science	Computational and Systems Biology	Human and Statistical Genetics	
+111647	"Pruett, John"	Biomedical Informatics and Data Science	Neurosciences		
+377277	"Puram, Sid"	Cancer Biology	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	
+341060	"Queller, David"	"Evolution, Ecology and Population Biology"	Molecular Genetics and Genomics	Plant and Microbial Biosciences	
+99486	"Raichle, Marcus"	Neurosciences			
+327096	"Rajagopal, Rithwick"	Molecular Cell Biology			
+334561	"Raman, Baranidharan"	Computational and Systems Biology	Neurosciences		
+341308	"Randolph, Gwendalyn"	Immunology	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+7922	"Ratner, Lee"	Cancer Biology	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+11554	"Rauchman, Michael"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics		
+501399	"Ravichandran, Kodi"	Immunology	Molecular Cell Biology		
+395342	"Reichhardt, Courtney"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Microbiology and Microbial Pathogenesis	
+83938	"Remedi, Maria"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Neurosciences	
+396405	"Renner, Susanne"	"Evolution, Ecology and Population Biology"			
+345999	"Rentschler, Stacey"	"Developmental, Regenerative and Stem Cell Biology"			
+396878	"Ribeiro Pereira, Patricia Manuela"	Cancer Biology			
+7601	"Rice, John"	Biomedical Informatics and Data Science	Human and Statistical Genetics		
+393467	"Richards, Linda"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+332046	"Roberson, Eli"	Biomedical Informatics and Data Science	Computational and Systems Biology	Human and Statistical Genetics	
+381411	"Robertson, Janice"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Neurosciences	
+114776	"Rogers, Cynthia"	Neurosciences			
+504466	"Roland, Jarod"	Neurosciences			
+117001	"Rosen, David"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+368831	"Rowlands, Elizabeth Yanik"	Biomedical Informatics and Data Science	Human and Statistical Genetics		
+394366	"Rubenstein, Ron"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+7394	"Rubin, Deborah"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"		
+302975	"Rubin, Josh"	Cancer Biology	Molecular Cell Biology	Neurosciences	
+39745	"Rudnick, David"	"Developmental, Regenerative and Stem Cell Biology"			
+382011	"Rudra, Shiva"	Molecular Microbiology and Microbial Pathogenesis			
+348747	"Rutherford, Mark"	Neurosciences			
+101060	"Saccone, Nancy"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+303473	"Saenz, Jose"	Molecular Cell Biology			
+381324	"Sah, Rajan"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+388626	"Saligrama, Naresha"	Biomedical Informatics and Data Science	Immunology	Neurosciences	
+22582	"Salkoff, Lawrence"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+348659	"Samineni, Vijay"	Computational and Systems Biology	Molecular Genetics and Genomics	Neurosciences	
+8680	"Sands, Mark"	Molecular Cell Biology	Molecular Genetics and Genomics	Neurosciences	
+89096	"Santi Grau Perez, Celia"	Molecular Cell Biology			
+393352	"Sardiello, Marco"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+31147	"Schaal, Barbara"	"Evolution, Ecology and Population Biology"	Plant and Microbial Biosciences		
+53713	"Schedl, Tim"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics		
+360887	"Scheller, Erica"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Neurosciences	
+112377	"Schilling, Joel"	Immunology			
+34851	"Schlesinger, Paul"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+9168	"Schreiber, Robert"	Cancer Biology	Immunology		
+313458	"Schuettpelz, Laura"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Genetics and Genomics	
+24684	"Schwartz, Alan"	Molecular Cell Biology			
+321947	"Schwartz, Drew"	Computational and Systems Biology	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+112562	"Schwarz, Julie"	Cancer Biology	Molecular Cell Biology		
+19626	"Semenkovich, Clay"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Genetics and Genomics		
+504932	"Sencan Egilmez, Ikbal"	Neurosciences			
+360124	"Setton, Lori"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+374218	"Shan, Liang"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+332082	"Shao, Jieya"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+20694	"Shao, Jin-Yu"	"Biochemistry, Biophysics, and Structural Biology"			
+54837	"Sharma, Vijay"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		
+304863	"Shaw, Paul"	Molecular Genetics and Genomics	Neurosciences		
+371596	"Sheets, Lavinia"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Neurosciences	
+358044	"Shen, Jie"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+105719	"Shiels, Alan"	Molecular Genetics and Genomics			
+4366	"Shimony, Joshua"	Neurosciences			
+314237	"Shoghi, Kooresh"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Cell Biology	
+110578	"Shokeen, Monica"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Immunology	
+24959	"Sibley, David"	Immunology	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+319695	"Silva, Jonathan"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Computational and Systems Biology	
+4321	"Silva, Matthew"	Human and Statistical Genetics	Molecular Cell Biology		
+340732	"Silva-Fisher, Jessica"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+25877	"Silverman, Gary"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+334131	"Singamaneni, Srikanth"	"Biochemistry, Biophysics, and Structural Biology"			
+384912	"Singh, Nathan"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Computational and Systems Biology	
+8943	"Skeath, James"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+324466	"Smyser, Christopher"	Neurosciences			
+7357	"Snyder, Lawrence"	Neurosciences			
+333984	"Solnica-Krezel, Lilianna"	"Developmental, Regenerative and Stem Cell Biology"			
+46410	"Song, Sheng-Kwei"	Neurosciences			
+369789	"Soranno, Andrea"	"Biochemistry, Biophysics, and Structural Biology"			
+383668	"Sotiras, Aris"	Biomedical Informatics and Data Science	Neurosciences		
+378334	"Souroullas, George"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+339790	"Spencer, David"	Cancer Biology	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	
+334785	"Stallings, Christina"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+111771	"Steed, Ashley"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+506522	"Stegh, Alexander"	Cancer Biology			
+10303	"Stein, Paul"	Neurosciences			
+304837	"Stewart-Wigglesworth, Sheila"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+31057	"Stitziel, Nathan"	Biomedical Informatics and Data Science	Computational and Systems Biology	Human and Statistical Genetics	
+349506	"Stone, Stephen"	"Developmental, Regenerative and Stem Cell Biology"			
+360852	"Strahle, Jennifer"	Neurosciences			
+341062	"Strassmann, Joan"	"Evolution, Ecology and Population Biology"	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+381028	"Stratman, Amber"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+324509	"Sutcliffe, Siobhan"	Biomedical Informatics and Data Science	Molecular Microbiology and Microbial Pathogenesis		
+331770	"Swamidass, Joshua"	Biomedical Informatics and Data Science	Computational and Systems Biology		
+398562	"Sykes, Stephen"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+4332	"Sylvester, Chad"	Neurosciences			
+37641	"Taghert, Paul"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences		
+355838	"Tague, Laneshia"	Biomedical Informatics and Data Science	Immunology	Molecular Genetics and Genomics	
+344318	"Tang, Simon"	"Biochemistry, Biophysics, and Structural Biology"			
+326197	"Tang, Yinjie"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Microbiology and Microbial Pathogenesis	
+300471	"Tarr, Phillip"	Molecular Microbiology and Microbial Pathogenesis			
+394919	"Tavoni, Gaia"	"Biochemistry, Biophysics, and Structural Biology"	Biomedical Informatics and Data Science	Computational and Systems Biology	
+12856	"Taylor, John-Stephen"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+10229	"Teitelbaum, Steven"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+359807	"Tello, Juan"	"Evolution, Ecology and Population Biology"			
+373972	"Theunissen, Thorold"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Genetics and Genomics	
+19886	"Thompson, Michael"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology		
+379803	"Thorek, Daniel"	Cancer Biology			
+376147	"Tikhonov, Mikhail"	Computational and Systems Biology	"Evolution, Ecology and Population Biology"		
+356007	"Topp, Christopher"	Biomedical Informatics and Data Science	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	
+345996	"Toriola, Adetunji"	Cancer Biology	Human and Statistical Genetics	Immunology	
+38296	"Tripathy, Sandeep"	Immunology			
+303193	"True, Heather"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+395670	"Tsai, Tony"	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+386087	"Turner, Tychele"	Computational and Systems Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+524118	"Uberoi, Aayushi"	Cancer Biology	Computational and Systems Biology	"Developmental, Regenerative and Stem Cell Biology"	
+52751	"Umen, James"	Molecular Genetics and Genomics	Plant and Microbial Biosciences		
+344743	"Urano, Fumihiko"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	Molecular Genetics and Genomics	
+378199	"Vahey, Michael"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Microbiology and Microbial Pathogenesis		
+357918	"Van Dyke-Blodgett, Joshua"	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	Plant and Microbial Biosciences	
+376797	"Van Dyken, Steven"	"Developmental, Regenerative and Stem Cell Biology"	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+101099	"Van Essen, David"	Neurosciences			
+326582	"Van Tine, Brian"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+36883	"Veis, Deborah"	Cancer Biology	Immunology	Molecular Cell Biology	
+360440	"Ver Heul, Aaron"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Neurosciences	
+500981	"Verma, Priyanka"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+361845	"Vierstra, Richard"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Plant and Microbial Biosciences	
+91793	"Vindigni, Alessandro"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+52080	"Vogel, Joseph"	Molecular Cell Biology	Molecular Genetics and Genomics	Molecular Microbiology and Microbial Pathogenesis	
+304528	"Wagenseil, Jessica"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Cell Biology	
+67331	"Walter, Matthew"	Cancer Biology	Molecular Genetics and Genomics		
+351211	"Wan, Xiaoxiao"	Immunology			
+307841	"Wang, David"	Computational and Systems Biology	Immunology	Molecular Microbiology and Microbial Pathogenesis	
+504453	"Wang, Jennifer"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+375506	"Wang, Leyao"	Biomedical Informatics and Data Science	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	
+397716	"Wang, Shuo"	Neurosciences			
+306435	"Wang, Ting"	Computational and Systems Biology	"Evolution, Ecology and Population Biology"	Human and Statistical Genetics	
+304508	"Warchol, Mark"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences		
+350900	"Ward, Jeffrey"	Cancer Biology	Immunology		
+333011	"Waters, Erika"	Human and Statistical Genetics	Molecular Genetics and Genomics		
+24072	"Watson, Mark"	Cancer Biology	Human and Statistical Genetics	Molecular Genetics and Genomics	
+39291	"Weber, Jason"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+115039	"Weihl, Conrad"	Molecular Cell Biology	Neurosciences		
+48662	"Weilbaecher, Katherine"	Cancer Biology	Molecular Cell Biology	Molecular Genetics and Genomics	
+351215	"Wencewicz, Timothy"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Microbiology and Microbial Pathogenesis	Plant and Microbial Biosciences	
+367852	"Wheelock, Muriah"	Biomedical Informatics and Data Science	Computational and Systems Biology	Neurosciences	
+389703	"Whelan, Sean"	"Biochemistry, Biophysics, and Structural Biology"	Immunology	Molecular Cell Biology	
+313856	"Williams, Philip"	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences		
+314979	"Willie, Jon"	Neurosciences			
+40768	"Wilson, David"	"Biochemistry, Biophysics, and Structural Biology"	"Developmental, Regenerative and Stem Cell Biology"		
+11381	"Wong, Michael"	Neurosciences			
+313627	"Wood, Matt"	Molecular Cell Biology	Neurosciences		
+53991	"Wu, Gregory"	Immunology	Neurosciences		
+517106	"Wu, Meng"	Computational and Systems Biology	Immunology	Molecular Genetics and Genomics	
+31882	"Wylie, Kristine"	Molecular Microbiology and Microbial Pathogenesis			
+86617	"Xu, Jinbin"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+23010	"Yablonskiy, Dmitriy"	Neurosciences			
+307990	"Yakusheva, Tatyana"	Neurosciences			
+320327	"Yang, Lan"	"Biochemistry, Biophysics, and Structural Biology"			
+344139	"Yano, Hiroko"	Molecular Cell Biology	Neurosciences		
+372112	"Yen, Po-Yin"	Biomedical Informatics and Data Science			
+367794	"Yi, Jason"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Neurosciences	
+104162	"Yokoyama, Wayne"	Immunology	Molecular Microbiology and Microbial Pathogenesis		
+340149	"Yoo, Andrew"	"Developmental, Regenerative and Stem Cell Biology"	Molecular Genetics and Genomics	Neurosciences	
+510503	"Yoshimatsu, Takeshi"	Neurosciences			
+329814	"You, Zhongsheng"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+14960	"Zacks, Jeffrey"	Neurosciences			
+347045	"Zaher, Hani"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology	Plant and Microbial Biosciences	
+355186	"Zayed, Mohamed"	"Biochemistry, Biophysics, and Structural Biology"	Cancer Biology	Molecular Cell Biology	
+346368	"Zhang, Fuzhong"	"Biochemistry, Biophysics, and Structural Biology"	Computational and Systems Biology	Molecular Microbiology and Microbial Pathogenesis	
+348721	"Zhang, Jin"	Biomedical Informatics and Data Science	Cancer Biology	Computational and Systems Biology	
+522138	"Zhang, Linying"	Biomedical Informatics and Data Science	Computational and Systems Biology		
+376157	"Zhang, Ru"	Molecular Cell Biology	Molecular Genetics and Genomics	Plant and Microbial Biosciences	
+370231	"Zhang, Rui"	"Biochemistry, Biophysics, and Structural Biology"	Molecular Cell Biology		
+309884	"Zhao, Guoyan"	Biomedical Informatics and Data Science	Computational and Systems Biology	Molecular Genetics and Genomics	
+506402	"Zhong, Xuehua"	Computational and Systems Biology	Molecular Genetics and Genomics	Plant and Microbial Biosciences	
+386619	"Zhou, Chao"	Cancer Biology	"Developmental, Regenerative and Stem Cell Biology"	Neurosciences	
+39236	"Zipfel, Gregory"	Neurosciences			
+74160	"Zorumski, Charles"	"Biochemistry, Biophysics, and Structural Biology"	Neurosciences		

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -271,14 +271,19 @@ fn replace_faculty_dataset(
 ) -> Result<FacultyDatasetStatus, String> {
     let trimmed = path.trim();
     if trimmed.is_empty() {
-        return Err("Select a TSV file to import for the faculty dataset.".into());
+        return Err("Select a TSV or TXT file to import for the faculty dataset.".into());
     }
 
-    let source = resolve_existing_path(Some(trimmed.to_string()), false, "Faculty dataset TSV")?;
+    let source = resolve_existing_path(Some(trimmed.to_string()), false, "Faculty dataset file")?;
 
     match source.extension().and_then(|ext| ext.to_str()) {
-        Some(ext) if ext.eq_ignore_ascii_case("tsv") => {}
-        _ => return Err("Select a tab-delimited .tsv file to replace the faculty dataset.".into()),
+        Some(ext)
+            if ext.eq_ignore_ascii_case("tsv") || ext.eq_ignore_ascii_case("txt") => {}
+        _ => {
+            return Err(
+                "Select a tab-delimited .tsv or .txt file to replace the faculty dataset.".into(),
+            )
+        }
     }
 
     let destination = dataset_destination(&app_handle)?;

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Cursor};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+use tauri::Manager;
 
 const FACULTY_DATASET_FILENAME: &str = "faculty_dataset.tsv";
 const DEFAULT_FACULTY_DATASET: &[u8] = include_bytes!("../assets/default_faculty_dataset.tsv");
@@ -95,7 +96,7 @@ struct SubmissionResponse {
     details: SubmissionDetails,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct SpreadsheetPreview {
     headers: Vec<String>,
@@ -414,7 +415,7 @@ fn read_delimited_spreadsheet(path: &Path) -> Result<(Vec<String>, Vec<Vec<Strin
     let mut rows = Vec::new();
     for record in reader.records() {
         let record = record.map_err(|err| format!("Unable to read spreadsheet rows: {err}"))?;
-        let mut values: Vec<String> = record
+        let values: Vec<String> = record
             .iter()
             .map(|value| value.trim().to_string())
             .collect();
@@ -455,7 +456,7 @@ fn read_excel_spreadsheet(path: &Path) -> Result<(Vec<String>, Vec<Vec<String>>)
     let mut rows = Vec::new();
 
     for row in rows_iter {
-        let mut values: Vec<String> = row.iter().map(cell_to_string).collect();
+        let values: Vec<String> = row.iter().map(cell_to_string).collect();
         if values.iter().all(|value| value.is_empty()) {
             continue;
         }

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -604,8 +604,7 @@ fn dataset_destination(app_handle: &tauri::AppHandle) -> Result<PathBuf, String>
     let base = app_handle
         .path()
         .app_data_dir()
-        .map_err(|err| format!("Unable to resolve the application data directory: {err}"))?
-        .ok_or_else(|| "The application data directory is not available.".to_string())?;
+        .map_err(|err| format!("Unable to resolve the application data directory: {err}"))?;
     Ok(base.join(FACULTY_DATASET_FILENAME))
 }
 

--- a/tauri-gui/src/App.css
+++ b/tauri-gui/src/App.css
@@ -175,6 +175,13 @@ button.secondary {
   box-shadow: 0 14px 28px rgba(15, 23, 42, 0.25);
 }
 
+button.ghost {
+  background: transparent;
+  color: #1d4ed8;
+  border: 1px solid #93c5fd;
+  box-shadow: none;
+}
+
 button.add-entry-button {
   align-self: flex-start;
   background: #0ea5e9;
@@ -355,6 +362,164 @@ button.add-entry-button:not(:disabled):hover {
 
 .number-row input[type="number"] {
   width: 140px;
+}
+
+.dataset-card {
+  margin-top: 1.75rem;
+  padding: 1.4rem 1.6rem;
+  border-radius: 18px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+}
+
+.dataset-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dataset-card-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.dataset-card-description {
+  margin-top: 0.35rem;
+  margin-bottom: 1.15rem;
+  color: #475569;
+}
+
+.dataset-status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.dataset-status-pill.ready {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.dataset-status-pill.warning {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.dataset-status-pill.loading {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.dataset-meta-grid {
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.dataset-meta-grid dt {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.dataset-meta-grid dd {
+  margin: 0.35rem 0 0;
+  color: #334155;
+  word-break: break-word;
+}
+
+.dataset-path {
+  font-family: "ui-monospace", SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85rem;
+}
+
+.dataset-message {
+  margin: 1rem 0 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.dataset-message-info {
+  background: #e0f2fe;
+  color: #075985;
+  border: 1px solid #7dd3fc;
+}
+
+.dataset-message-error {
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fca5a5;
+}
+
+.dataset-actions {
+  margin-top: 1.35rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.dataset-status-banner {
+  margin-top: 1.25rem;
+}
+
+.dataset-preview-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 40;
+}
+
+.dataset-preview-dialog {
+  max-width: 860px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.3);
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+}
+
+.dataset-preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.dataset-preview-header h3 {
+  margin: 0;
+}
+
+.dataset-preview-card {
+  gap: 0.75rem;
+}
+
+.dataset-preview-card .preview-table-wrapper {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.dataset-preview-card .small-note {
+  color: #475569;
+}
+
+.close-button {
+  padding: 0.5rem 1rem;
 }
 
 .program-checkbox-grid {
@@ -685,5 +850,70 @@ button.add-entry-button:not(:disabled):hover {
 
   button.secondary {
     background: #1d4ed8;
+  }
+
+  button.ghost {
+    color: #93c5fd;
+    border-color: #1d4ed8;
+  }
+
+  .dataset-card {
+    background: #0f172a;
+    border-color: #1f2937;
+    box-shadow: 0 24px 60px rgba(2, 6, 23, 0.65);
+  }
+
+  .dataset-card-description {
+    color: #cbd5f5;
+  }
+
+  .dataset-meta-grid dt {
+    color: #e2e8f0;
+  }
+
+  .dataset-meta-grid dd {
+    color: #cbd5f5;
+  }
+
+  .dataset-status-pill.ready {
+    background: rgba(22, 101, 52, 0.25);
+    color: #bbf7d0;
+  }
+
+  .dataset-status-pill.warning {
+    background: rgba(185, 28, 28, 0.2);
+    color: #fecaca;
+  }
+
+  .dataset-status-pill.loading {
+    background: rgba(3, 105, 161, 0.2);
+    color: #bae6fd;
+  }
+
+  .dataset-message-info {
+    background: rgba(14, 165, 233, 0.18);
+    border-color: rgba(56, 189, 248, 0.35);
+    color: #bae6fd;
+  }
+
+  .dataset-message-error {
+    background: rgba(220, 38, 38, 0.22);
+    border-color: rgba(248, 113, 113, 0.35);
+    color: #fecaca;
+  }
+
+  .dataset-preview-dialog {
+    background: #0f172a;
+    border-color: #1f2937;
+    box-shadow: 0 30px 70px rgba(2, 6, 23, 0.7);
+  }
+
+  .dataset-preview-card {
+    background: #111827;
+    border-color: #1f2937;
+  }
+
+  .dataset-preview-card .small-note {
+    color: #cbd5f5;
   }
 }

--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -193,7 +193,7 @@ function App() {
         filters: [
           {
             name: "Faculty dataset",
-            extensions: ["tsv"],
+            extensions: ["tsv", "txt"],
           },
         ],
       });

--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -193,7 +193,7 @@ function App() {
         filters: [
           {
             name: "Faculty dataset",
-            extensions: ["tsv", "txt"],
+            extensions: ["tsv", "txt", "xlsx", "xls"],
           },
         ],
       });
@@ -1008,8 +1008,8 @@ function App() {
               </span>
             </div>
             <p className="dataset-card-description">
-              Manage the TSV that seeds the faculty embedding index before
-              running updates.
+              Manage the dataset file that seeds the faculty embedding index
+              before running updates.
             </p>
             <dl className="dataset-meta-grid">
               <div>
@@ -1293,7 +1293,7 @@ function App() {
               <div className="spreadsheet-preview-card dataset-preview-card">
                 <p className="small-note">
                   Showing the first {datasetStatus.preview.rows.length} rows of
-                  the active TSV.
+                  the active dataset file.
                 </p>
                 <div className="preview-table-wrapper">
                   <table className="preview-table">


### PR DESCRIPTION
## Summary
- add Tauri commands to manage the faculty dataset, compute metadata, and surface a packaged default TSV
- extend the React UI with a faculty dataset manager card, preview dialog, and disable embedding refresh until the dataset is valid
- style the dataset manager and preview overlay to align with the existing design system

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc8fc06aa48325bb78cc6386026173