### PR TITLE
Update document input label and remove inline embedding refresh

### DIFF
--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -52,7 +52,6 @@ struct SubmissionPayload {
     custom_faculty_path: Option<String>,
     faculty_recs_per_student: u32,
     student_recs_per_faculty: u32,
-    update_embeddings: bool,
     #[serde(default)]
     spreadsheet_prompt_columns: Vec<String>,
     #[serde(default)]
@@ -85,7 +84,6 @@ struct SubmissionDetails {
     custom_faculty_path: Option<String>,
     recommendations_per_student: u32,
     recommendations_per_faculty: u32,
-    update_embeddings: bool,
     prompt_preview: Option<String>,
     spreadsheet_prompt_columns: Vec<String>,
     spreadsheet_identifier_columns: Vec<String>,
@@ -181,7 +179,6 @@ fn submit_matching_request(payload: SubmissionPayload) -> Result<SubmissionRespo
         custom_faculty_path,
         faculty_recs_per_student,
         student_recs_per_faculty,
-        update_embeddings,
         spreadsheet_prompt_columns,
         spreadsheet_identifier_columns,
     } = payload;
@@ -205,7 +202,7 @@ fn submit_matching_request(payload: SubmissionPayload) -> Result<SubmissionRespo
             prompt_preview = Some(build_prompt_preview(text));
         }
         TaskType::Document => {
-            let document = resolve_existing_path(document_path, false, "Document file")?;
+            let document = resolve_existing_path(document_path, false, "Single document")?;
             if let Some(message) =
                 validate_extension(&document, &["txt", "pdf", "doc", "docx"], "document")
             {
@@ -277,7 +274,6 @@ fn submit_matching_request(payload: SubmissionPayload) -> Result<SubmissionRespo
         custom_faculty_path: faculty_roster_path.clone(),
         recommendations_per_student: faculty_recs_per_student,
         recommendations_per_faculty: student_recs_per_faculty,
-        update_embeddings,
         prompt_preview,
         spreadsheet_prompt_columns: selected_prompt_columns.clone(),
         spreadsheet_identifier_columns: selected_identifier_columns.clone(),
@@ -288,7 +284,6 @@ fn submit_matching_request(payload: SubmissionPayload) -> Result<SubmissionRespo
         &faculty_scope,
         faculty_recs_per_student,
         student_recs_per_faculty,
-        update_embeddings,
         details.program_filters.len(),
         faculty_roster_path.is_some(),
     );
@@ -1464,7 +1459,6 @@ fn build_summary(
     faculty_scope: &FacultyScope,
     faculty_per_student: u32,
     students_per_faculty: u32,
-    update_embeddings: bool,
     program_count: usize,
     has_custom_roster: bool,
 ) -> String {
@@ -1500,10 +1494,6 @@ fn build_summary(
             " Each faculty member will receive up to {students_per_faculty} student recommendation{plural}.",
             plural = if students_per_faculty == 1 { "" } else { "s" }
         ));
-    }
-
-    if update_embeddings {
-        summary.push_str(" Faculty embeddings will be refreshed before matching.");
     }
 
     summary

--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -56,7 +56,6 @@ interface SubmissionDetails {
   customFacultyPath: string | null;
   recommendationsPerStudent: number;
   recommendationsPerFaculty: number;
-  updateEmbeddings: boolean;
   promptPreview?: string;
   spreadsheetPromptColumns: string[];
   spreadsheetIdentifierColumns: string[];
@@ -85,7 +84,6 @@ function App() {
   const [customFacultyPath, setCustomFacultyPath] = useState("");
   const [facultyRecCount, setFacultyRecCount] = useState("10");
   const [studentRecCount, setStudentRecCount] = useState("0");
-  const [updateEmbeddings, setUpdateEmbeddings] = useState(false);
 
   const [spreadsheetPreview, setSpreadsheetPreview] =
     useState<SpreadsheetPreview | null>(null);
@@ -733,7 +731,6 @@ function App() {
                 : undefined,
             facultyRecsPerStudent: facultyRecommendations,
             studentRecsPerFaculty: studentRecommendations,
-            updateEmbeddings,
             spreadsheetPromptColumns:
               taskType === "spreadsheet"
                 ? mapSelectedColumns(selectedPromptColumns)
@@ -801,7 +798,7 @@ function App() {
                   checked={taskType === "document"}
                   onChange={() => handleTaskTypeChange("document")}
                 />
-                <span>Document file</span>
+                <span>Single document</span>
               </label>
               <label className="radio-option">
                 <input
@@ -1194,17 +1191,6 @@ function App() {
                 />
               </label>
             </div>
-            <div className="checkbox-row">
-              <input
-                id="update-embeddings"
-                type="checkbox"
-                checked={updateEmbeddings}
-                onChange={(event) => setUpdateEmbeddings(event.target.checked)}
-              />
-              <label htmlFor="update-embeddings">
-                Refresh faculty embeddings before running this match
-              </label>
-            </div>
           </fieldset>
 
           <section className="dataset-card">
@@ -1479,8 +1465,6 @@ function App() {
                   <dd>{result.details.recommendationsPerStudent}</dd>
                   <dt>Students per faculty</dt>
                   <dd>{result.details.recommendationsPerFaculty}</dd>
-                  <dt>Refresh embeddings</dt>
-                  <dd>{result.details.updateEmbeddings ? "Yes" : "No"}</dd>
                 </dl>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- rename the document input option to "Single document" in the UI and the corresponding validation text
- drop the inline "refresh embeddings before match" toggle so embedding updates rely on the dedicated action

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd6a6dc480832596b22ef71b966b79