### PR TITLE
Track faculty dataset source path

### DIFF
--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -37,6 +37,7 @@ interface FacultyDatasetPreviewResult {
 interface FacultyDatasetStatus {
   path: string | null;
   canonicalPath: string | null;
+  sourcePath: string | null;
   lastModified: string | null;
   rowCount: number | null;
   columnCount: number | null;
@@ -1222,9 +1223,10 @@ function App() {
                 <dd className="dataset-path">
                   {isDatasetLoading
                     ? "Loading…"
-                    : datasetStatus?.canonicalPath ??
-                      datasetStatus?.path ??
-                      "Not configured"}
+                    : datasetStatus?.sourcePath ??
+                        datasetStatus?.canonicalPath ??
+                        datasetStatus?.path ??
+                        "Not configured"}
                 </dd>
               </div>
               <div>


### PR DESCRIPTION
## Summary
- persist the original source path each time a faculty dataset is imported or restored
- expose the stored path to the frontend and prefer it for the "Active file" display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd6c46c4cc8325803450d86cd761eb