### PR TITLE
Remove redundant GUI header description

### DIFF
--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -765,10 +765,6 @@ function App() {
       <main>
         <header className="page-header">
           <h1>DBBS Faculty Recommendation Console</h1>
-          <p className="description">
-            Configure matching runs, narrow the faculty roster, and track the
-            options that will be sent to the matching backend.
-          </p>
         </header>
 
         <form className="matching-form" onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- remove the descriptive paragraph beneath the console title to declutter the header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd6f9852e483258ec9a7fcd3a90394