### PR TITLE
Implement PubMedBERT-backed faculty embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ pnpm-debug.log*
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+**/.venv

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -386,7 +386,7 @@ fn emit_faculty_embedding_progress(
     app_handle: &tauri::AppHandle,
     progress: EmbeddingProgressUpdate,
 ) {
-    let _ = app_handle.emit_all(FACULTY_EMBEDDING_PROGRESS_EVENT, progress);
+    let _ = app_handle.emit(FACULTY_EMBEDDING_PROGRESS_EVENT, progress);
 }
 
 fn emit_embedding_error(app_handle: &tauri::AppHandle, total_rows: usize, message: &str) {
@@ -1520,7 +1520,7 @@ fn analyze_faculty_dataset(
 
     let column_count = headers.len();
 
-    let (mut embedding_indexes, mut identifier_indexes) = if let Some(config) = overrides {
+    let (embedding_indexes, identifier_indexes) = if let Some(config) = overrides {
         (
             normalize_column_selection(&config.embedding_columns, column_count),
             normalize_column_selection(&config.identifier_columns, column_count),
@@ -1529,7 +1529,7 @@ fn analyze_faculty_dataset(
         suggest_spreadsheet_columns(&headers, &rows)
     };
 
-    let mut program_indexes = if let Some(config) = overrides {
+    let program_indexes = if let Some(config) = overrides {
         normalize_column_selection(&config.program_columns, column_count)
     } else {
         suggest_program_columns(&headers, &rows)

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -404,7 +404,16 @@ fn emit_embedding_error(app_handle: &tauri::AppHandle, total_rows: usize, messag
 }
 
 #[tauri::command]
-fn update_faculty_embeddings(app_handle: tauri::AppHandle) -> Result<String, String> {
+async fn update_faculty_embeddings(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let result =
+        tauri::async_runtime::spawn_blocking(move || perform_faculty_embedding_refresh(app_handle))
+            .await
+            .map_err(|err| format!("Embedding refresh task failed: {err}"))?;
+
+    Ok(result)
+}
+
+fn perform_faculty_embedding_refresh(app_handle: tauri::AppHandle) -> Result<String, String> {
     let started_at = Instant::now();
     emit_faculty_embedding_progress(
         &app_handle,

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -410,7 +410,7 @@ async fn update_faculty_embeddings(app_handle: tauri::AppHandle) -> Result<Strin
             .await
             .map_err(|err| format!("Embedding refresh task failed: {err}"))?;
 
-    Ok(result)
+    Ok(result?)
 }
 
 fn perform_faculty_embedding_refresh(app_handle: tauri::AppHandle) -> Result<String, String> {

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::io::{BufRead, BufReader, Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Instant, SystemTime};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 const FACULTY_DATASET_BASENAME: &str = "faculty_dataset";
 const FACULTY_DATASET_DEFAULT_EXTENSION: &str = "tsv";


### PR DESCRIPTION
## Summary
- generate faculty embeddings by reading the validated dataset, collecting identifier/text pairs, and invoking a Python helper that loads NeuML/pubmedbert-base-embeddings
- persist the resulting vectors plus metadata to a JSON index within the dataset directory and return a detailed status message to the UI
- add utility helpers for header lookups and resilient Python execution, including graceful handling when dependencies are missing

## Testing
- cargo fmt --all
- cargo check *(fails: missing system library glib-2.0 required by glib-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68cd78378f0c8325be2e375a323fd43b