### PR TITLE
Make matching request asynchronous

### DIFF
--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -176,7 +176,16 @@ struct FacultyProgramMembership {
 }
 
 #[tauri::command]
-fn submit_matching_request(
+async fn submit_matching_request(
+    app_handle: tauri::AppHandle,
+    payload: SubmissionPayload,
+) -> Result<SubmissionResponse, String> {
+    tauri::async_runtime::spawn_blocking(move || perform_matching_request(app_handle, payload))
+        .await
+        .map_err(|err| format!("Matching task failed: {err}"))?
+}
+
+fn perform_matching_request(
     app_handle: tauri::AppHandle,
     payload: SubmissionPayload,
 ) -> Result<SubmissionResponse, String> {


### PR DESCRIPTION
## Summary
- run matching requests on a background thread via `spawn_blocking` so the GUI no longer freezes while waiting for results
- keep the existing matching logic intact inside a new helper that is invoked asynchronously

## Testing
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: missing system dependency glib-2.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc5b756748325a7355cb95766f904