### PR TITLE
Support text extraction for document matching

### DIFF
--- a/tauri-gui/src-tauri/Cargo.toml
+++ b/tauri-gui/src-tauri/Cargo.toml
@@ -26,4 +26,7 @@ serde_json = "1"
 csv = "1"
 calamine = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+docx-rs = "0.4"
+pdf-extract = "0.9"
+rtf-parser = "0.4"
 


### PR DESCRIPTION
## Summary
- add docx, PDF, and RTF/plain text extraction helpers and dependencies
- populate document uploads with extracted text so they are embedded like prompts
- reuse prompt matching flow for documents while keeping a preview-friendly display

## Testing
- `cargo fmt`
- `cargo test` *(fails: system library `glib-2.0` missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced67b11308325b9d007a1dbf9adf0