### PR TITLE
Add directory document matching workflow with preview/export

### DIFF
--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -111,6 +111,8 @@ struct SubmissionResponse {
     warnings: Vec<String>,
     details: SubmissionDetails,
     prompt_matches: Vec<PromptMatchResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    directory_results: Option<DirectoryMatchResults>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -222,6 +224,7 @@ fn perform_matching_request(
     let mut selected_prompt_columns = Vec::new();
     let mut selected_identifier_columns = Vec::new();
     let mut prepared_prompt_text: Option<String> = None;
+    let mut directory_source: Option<PathBuf> = None;
 
     match task_type {
         TaskType::Prompt => {
@@ -278,6 +281,7 @@ fn perform_matching_request(
                 }
             }
             validated_paths.push(PathConfirmation::new("Directory", &directory));
+            directory_source = Some(directory);
         }
     }
 
@@ -344,18 +348,30 @@ fn perform_matching_request(
     );
 
     let mut prompt_matches = Vec::new();
-    if let Some(prompt_text) = prepared_prompt_text {
-        let embedding_index = load_faculty_embedding_index(&app_handle)?;
-        if embedding_index.entries.is_empty() {
+    let mut directory_results = None;
+
+    let needs_prompt_embedding =
+        prepared_prompt_text.is_some() || matches!(task_type, TaskType::Directory);
+    let mut faculty_embedding_index: Option<FacultyEmbeddingIndex> = None;
+
+    if needs_prompt_embedding {
+        let index = load_faculty_embedding_index(&app_handle)?;
+        if index.entries.is_empty() {
             return Err(
                 "No faculty embeddings are available. Generate embeddings before matching.".into(),
             );
         }
+        faculty_embedding_index = Some(index);
+    }
 
+    if let Some(prompt_text) = prepared_prompt_text {
         let limit = faculty_recs_per_student.max(1) as usize;
-        let prompt_embedding = embed_prompt(&app_handle, &embedding_index, &prompt_text)?;
+        let embedding_index = faculty_embedding_index
+            .as_ref()
+            .ok_or_else(|| "The faculty embedding index was not loaded.".to_string())?;
+        let prompt_embedding = embed_prompt(&app_handle, embedding_index, &prompt_text)?;
         let matches = find_best_faculty_matches(
-            &embedding_index,
+            embedding_index,
             &prompt_embedding,
             limit,
             allowed_faculty_rows.as_ref(),
@@ -370,11 +386,34 @@ fn perform_matching_request(
         });
     }
 
+    if matches!(task_type, TaskType::Directory) {
+        let directory_path = directory_source
+            .as_ref()
+            .ok_or_else(|| "The directory path was not preserved during processing.".to_string())?;
+        let embedding_index = faculty_embedding_index
+            .as_ref()
+            .ok_or_else(|| "The faculty embedding index was not loaded.".to_string())?;
+        let limit = faculty_recs_per_student.max(1) as usize;
+
+        let outcome = process_directory_documents(
+            &app_handle,
+            directory_path,
+            embedding_index,
+            limit,
+            allowed_faculty_rows.as_ref(),
+        )?;
+
+        warnings.extend(outcome.warnings);
+        prompt_matches.extend(outcome.prompt_matches);
+        directory_results = Some(outcome.results);
+    }
+
     Ok(SubmissionResponse {
         summary,
         warnings,
         details,
         prompt_matches,
+        directory_results,
     })
 }
 
@@ -459,6 +498,32 @@ struct FacultyMatchResult {
     row_index: usize,
     similarity: f32,
     identifiers: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct GeneratedSpreadsheet {
+    filename: String,
+    mime_type: String,
+    content: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DirectoryMatchResults {
+    processed_documents: usize,
+    matched_documents: usize,
+    skipped_documents: usize,
+    total_rows: usize,
+    preview: SpreadsheetPreview,
+    spreadsheet: GeneratedSpreadsheet,
+}
+
+#[derive(Debug)]
+struct DirectoryProcessingOutcome {
+    warnings: Vec<String>,
+    prompt_matches: Vec<PromptMatchResult>,
+    results: DirectoryMatchResults,
 }
 
 fn load_faculty_embedding_index(
@@ -564,6 +629,312 @@ fn find_best_faculty_matches(
     });
     candidates.truncate(limit);
     candidates
+}
+
+fn process_directory_documents(
+    app_handle: &tauri::AppHandle,
+    directory: &Path,
+    index: &FacultyEmbeddingIndex,
+    limit: usize,
+    allowed_rows: Option<&HashSet<usize>>,
+) -> Result<DirectoryProcessingOutcome, String> {
+    #[derive(Debug)]
+    struct DirectoryDocumentContext {
+        result_index: usize,
+        prompt: String,
+    }
+
+    #[derive(Debug)]
+    struct DirectoryDocumentResult {
+        identifier: String,
+        preview: String,
+        matches: Vec<FacultyMatchResult>,
+        status_message: Option<String>,
+    }
+
+    let mut warnings = Vec::new();
+    let mut document_results: Vec<DirectoryDocumentResult> = Vec::new();
+    let mut contexts: Vec<DirectoryDocumentContext> = Vec::new();
+    let mut file_paths: Vec<PathBuf> = Vec::new();
+
+    let reader = fs::read_dir(directory).map_err(|err| {
+        format!(
+            "Unable to read the directory '{}': {err}",
+            directory.display()
+        )
+    })?;
+
+    for entry in reader {
+        match entry {
+            Ok(entry) => {
+                let path = entry.path();
+                match entry.file_type() {
+                    Ok(file_type) => {
+                        if file_type.is_file() {
+                            file_paths.push(path);
+                        }
+                    }
+                    Err(err) => warnings.push(format!(
+                        "Skipped '{}': unable to determine the file type ({err}).",
+                        path.to_string_lossy()
+                    )),
+                }
+            }
+            Err(err) => warnings.push(format!(
+                "Unable to read an entry in '{}': {err}",
+                directory.display()
+            )),
+        }
+    }
+
+    file_paths.sort();
+
+    for path in file_paths {
+        let identifier = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| path.to_string_lossy().into_owned());
+
+        let mut result = DirectoryDocumentResult {
+            identifier: identifier.clone(),
+            preview: String::new(),
+            matches: Vec::new(),
+            status_message: None,
+        };
+        let mut prompt_text: Option<String> = None;
+
+        match extract_document_prompt(&path) {
+            Ok(DocumentExtractionResult {
+                text,
+                warnings: extraction_warnings,
+            }) => {
+                for warning in extraction_warnings {
+                    warnings.push(format!("{identifier}: {warning}"));
+                }
+
+                if text.trim().is_empty() {
+                    let message =
+                        format!("Skipped '{identifier}' because it did not contain readable text.");
+                    warnings.push(message.clone());
+                    result.status_message = Some(message);
+                } else {
+                    result.preview = build_prompt_preview(&text);
+                    prompt_text = Some(text);
+                }
+            }
+            Err(err) => {
+                warnings.push(err.clone());
+                result.status_message = Some(err);
+            }
+        }
+
+        let result_index = document_results.len();
+        if let Some(text) = prompt_text {
+            contexts.push(DirectoryDocumentContext {
+                result_index,
+                prompt: text,
+            });
+        }
+
+        document_results.push(result);
+    }
+
+    if document_results.is_empty() {
+        warnings.push("The selected directory did not contain any files to process.".into());
+    }
+
+    let mut prompt_matches = Vec::new();
+    let mut missing_embeddings = 0usize;
+
+    if !contexts.is_empty() {
+        let model_name = if index.model.trim().is_empty() {
+            DEFAULT_EMBEDDING_MODEL.to_string()
+        } else {
+            index.model.clone()
+        };
+
+        let payload = EmbeddingRequestPayload {
+            model: model_name,
+            texts: contexts
+                .iter()
+                .enumerate()
+                .map(|(id, context)| EmbeddingRequestRow {
+                    id,
+                    text: context.prompt.clone(),
+                })
+                .collect(),
+            item_label: Some("document".into()),
+            item_label_plural: Some("documents".into()),
+        };
+
+        let response = run_embedding_helper(app_handle, &payload)?;
+        if response.dimension != index.dimension {
+            return Err(format!(
+                "The document embedding dimension ({}) does not match the faculty embedding dimension ({}).",
+                response.dimension, index.dimension
+            ));
+        }
+
+        let mut embedding_map: HashMap<usize, Vec<f32>> = HashMap::new();
+        for row in response.rows {
+            embedding_map.insert(row.id, row.embedding);
+        }
+
+        for (context_index, context) in contexts.iter().enumerate() {
+            let identifier = document_results[context.result_index].identifier.clone();
+            let preview = document_results[context.result_index].preview.clone();
+
+            match embedding_map.remove(&context_index) {
+                Some(embedding) => {
+                    let matches = find_best_faculty_matches(index, &embedding, limit, allowed_rows);
+                    let matches_for_prompt = matches.clone();
+
+                    if matches_for_prompt.is_empty() {
+                        document_results[context.result_index].status_message =
+                            Some("No faculty matches were returned.".into());
+                    } else {
+                        document_results[context.result_index].status_message = None;
+                    }
+
+                    document_results[context.result_index].matches = matches;
+                    let prompt_label = if preview.is_empty() {
+                        identifier.clone()
+                    } else {
+                        format!("{identifier} — {preview}")
+                    };
+                    prompt_matches.push(PromptMatchResult {
+                        prompt: prompt_label,
+                        faculty_matches: matches_for_prompt,
+                    });
+                }
+                None => {
+                    missing_embeddings += 1;
+                    let message = "The embedding helper did not return a result for this document."
+                        .to_string();
+                    document_results[context.result_index].status_message = Some(message.clone());
+                    warnings.push(format!(
+                        "The embedding helper did not return an embedding for '{}'.",
+                        identifier
+                    ));
+
+                    let prompt_label = if preview.is_empty() {
+                        identifier.clone()
+                    } else {
+                        format!("{identifier} — {preview}")
+                    };
+                    prompt_matches.push(PromptMatchResult {
+                        prompt: prompt_label,
+                        faculty_matches: Vec::new(),
+                    });
+                }
+            }
+        }
+    } else if !document_results.is_empty() {
+        warnings
+            .push("None of the files in the directory contained readable text to embed.".into());
+    }
+
+    let processed_documents = if contexts.is_empty() {
+        0
+    } else {
+        contexts.len().saturating_sub(missing_embeddings)
+    };
+    let skipped_documents = document_results.len().saturating_sub(processed_documents);
+    let matched_documents = document_results
+        .iter()
+        .filter(|result| !result.matches.is_empty())
+        .count();
+
+    let mut headers = vec![
+        "Document".to_string(),
+        "Rank".to_string(),
+        "Similarity".to_string(),
+    ];
+    headers.extend(index.identifier_columns.clone());
+    headers.push("Faculty Row Index".to_string());
+
+    let mut rows = Vec::new();
+    for result in &document_results {
+        if result.matches.is_empty() {
+            let message = result
+                .status_message
+                .clone()
+                .unwrap_or_else(|| "No faculty matches were returned.".into());
+            let mut row = vec![result.identifier.clone(), String::new(), message];
+            for _ in &index.identifier_columns {
+                row.push(String::new());
+            }
+            row.push(String::new());
+            rows.push(row);
+            continue;
+        }
+
+        for (rank, faculty) in result.matches.iter().enumerate() {
+            let mut row = vec![
+                result.identifier.clone(),
+                (rank + 1).to_string(),
+                format_similarity_percent(faculty.similarity),
+            ];
+            for label in &index.identifier_columns {
+                row.push(faculty.identifiers.get(label).cloned().unwrap_or_default());
+            }
+            row.push(faculty.row_index.to_string());
+            rows.push(row);
+        }
+    }
+
+    let preview_rows: Vec<Vec<String>> = rows.iter().take(20).cloned().collect();
+    let preview = SpreadsheetPreview {
+        headers: headers.clone(),
+        rows: preview_rows,
+        suggested_prompt_columns: Vec::new(),
+        suggested_identifier_columns: Vec::new(),
+    };
+
+    let mut writer = csv::WriterBuilder::new()
+        .delimiter(b'\t')
+        .from_writer(Vec::new());
+    writer
+        .write_record(headers.iter())
+        .map_err(|err| format!("Unable to write the directory match header row: {err}"))?;
+    for row in &rows {
+        writer
+            .write_record(row.iter())
+            .map_err(|err| format!("Unable to write a directory match row: {err}"))?;
+    }
+    let tsv_bytes = writer
+        .into_inner()
+        .map_err(|err| format!("Unable to finalize the directory match spreadsheet: {err}"))?;
+    let tsv_content = String::from_utf8(tsv_bytes)
+        .map_err(|err| format!("The directory match spreadsheet contained invalid UTF-8: {err}"))?;
+
+    let results = DirectoryMatchResults {
+        processed_documents,
+        matched_documents,
+        skipped_documents,
+        total_rows: rows.len(),
+        preview,
+        spreadsheet: GeneratedSpreadsheet {
+            filename: "directory_matches.tsv".into(),
+            mime_type: "text/tab-separated-values".into(),
+            content: tsv_content,
+        },
+    };
+
+    Ok(DirectoryProcessingOutcome {
+        warnings,
+        prompt_matches,
+        results,
+    })
+}
+
+fn format_similarity_percent(value: f32) -> String {
+    if value.is_finite() {
+        format!("{:.1}%", value * 100.0)
+    } else {
+        "n/a".into()
+    }
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {

--- a/tauri-gui/src/App.css
+++ b/tauri-gui/src/App.css
@@ -793,6 +793,21 @@ button.theme-toggle:focus-visible {
   gap: 1.5rem;
 }
 
+.directory-results {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.directory-results .spreadsheet-preview-card {
+  margin-top: 0.75rem;
+}
+
+.directory-results .button-row {
+  justify-content: flex-start;
+}
+
 .match-card {
   border: 1px solid var(--washu-border);
   border-radius: 16px;

--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -22,6 +22,21 @@ interface SpreadsheetPreview {
   suggestedIdentifierColumns: number[];
 }
 
+interface GeneratedSpreadsheet {
+  filename: string;
+  mimeType: string;
+  content: string;
+}
+
+interface DirectoryMatchResults {
+  processedDocuments: number;
+  matchedDocuments: number;
+  skippedDocuments: number;
+  totalRows: number;
+  preview: SpreadsheetPreview;
+  spreadsheet: GeneratedSpreadsheet;
+}
+
 interface FacultyDatasetAnalysis {
   embeddingColumns: string[];
   identifierColumns: string[];
@@ -80,6 +95,7 @@ interface SubmissionResponse {
   warnings: string[];
   details: SubmissionDetails;
   promptMatches: PromptMatchResult[];
+  directoryResults?: DirectoryMatchResults;
 }
 
 interface StatusMessage {
@@ -930,14 +946,77 @@ function App() {
           ? submissionError.message
           : String(submissionError);
       setError(message);
-    } finally {
-      setIsSubmitting(false);
+  } finally {
+    setIsSubmitting(false);
+  }
+};
+
+  const handleDownloadDirectoryResults = useCallback(() => {
+    if (!result?.directoryResults) {
+      return;
     }
-  };
+
+    const { spreadsheet } = result.directoryResults;
+    if (!spreadsheet?.content) {
+      setError("The directory results are not available for download.");
+      return;
+    }
+
+    try {
+      const blob = new Blob([spreadsheet.content], {
+        type: spreadsheet.mimeType || "text/tab-separated-values",
+      });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download =
+        spreadsheet.filename && spreadsheet.filename.trim().length > 0
+          ? spreadsheet.filename
+          : "directory_matches.tsv";
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    } catch (downloadError) {
+      const message =
+        downloadError instanceof Error
+          ? downloadError.message
+          : String(downloadError);
+      setError(`Unable to generate the download: ${message}`);
+    }
+  }, [result, setError]);
 
   const handleEmbeddingsUpdate = async () => {
     await runEmbeddingRefresh(datasetStatus);
   };
+
+  const directorySummaryText = result?.directoryResults
+    ? (() => {
+        const { processedDocuments, matchedDocuments, skippedDocuments } =
+          result.directoryResults;
+        const sentences: string[] = [];
+        sentences.push(
+          `Processed ${processedDocuments} document${
+            processedDocuments === 1 ? "" : "s"
+          }`,
+        );
+        sentences.push(
+          matchedDocuments === 0
+            ? "No matches were produced"
+            : `${matchedDocuments} document${
+                matchedDocuments === 1 ? "" : "s"
+              } produced matches`,
+        );
+        if (skippedDocuments > 0) {
+          sentences.push(
+            `${skippedDocuments} document${
+              skippedDocuments === 1 ? " was" : "s were"
+            } skipped due to missing content or errors`,
+          );
+        }
+        return `${sentences.join(". ")}.`;
+      })()
+    : null;
 
   return (
     <div className="app-shell">
@@ -1664,7 +1743,73 @@ function App() {
               </div>
             </div>
 
-            {result.promptMatches.length > 0 && (
+            {result.directoryResults && (
+              <section className="directory-results">
+                <h3>Directory match preview</h3>
+                {directorySummaryText && (
+                  <p className="section-description">{directorySummaryText}</p>
+                )}
+                {result.directoryResults.preview.rows.length > 0 ? (
+                  <>
+                    <div className="spreadsheet-preview-card">
+                      <div className="spreadsheet-preview">
+                        <table>
+                          <thead>
+                            <tr>
+                              {result.directoryResults.preview.headers.map(
+                                (header, headerIndex) => (
+                                  <th key={`directory-header-${headerIndex}`}>
+                                    {header}
+                                  </th>
+                                ),
+                              )}
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {result.directoryResults.preview.rows.map(
+                              (row, rowIndex) => (
+                                <tr key={`directory-row-${rowIndex}`}>
+                                  {row.map((cell, cellIndex) => (
+                                    <td
+                                      key={`directory-cell-${rowIndex}-${cellIndex}`}
+                                    >
+                                      {cell}
+                                    </td>
+                                  ))}
+                                </tr>
+                              ),
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                    <p className="small-note">
+                      Showing {result.directoryResults.preview.rows.length}
+                      {result.directoryResults.totalRows >
+                      result.directoryResults.preview.rows.length
+                        ? ` of ${result.directoryResults.totalRows}`
+                        : ""}{" "}
+                      row{result.directoryResults.totalRows === 1 ? "" : "s"}.
+                    </p>
+                  </>
+                ) : (
+                  <p className="small-note">
+                    No match rows were generated for the available documents.
+                  </p>
+                )}
+                <div className="button-row">
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={handleDownloadDirectoryResults}
+                  >
+                    Download match spreadsheet
+                  </button>
+                </div>
+              </section>
+            )}
+
+            {result.promptMatches.length > 0 && !result.directoryResults && (
               <section className="match-results">
                 {result.promptMatches.map((match, matchIndex) => (
                   <article className="match-card" key={`match-${matchIndex}`}>


### PR DESCRIPTION
## Summary
- expand the backend directory task to embed each readable file, accumulate warnings, and emit match tables plus TSV content
- show a directory results preview and download action in the React UI alongside a status summary
- add styling for the new directory results section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee4742da08325bfbab7ba2b80d684