### PR TITLE
Display faculty text for single prompt matches

### DIFF
--- a/tauri-gui/src/App.css
+++ b/tauri-gui/src/App.css
@@ -892,6 +892,21 @@ button.theme-toggle:focus-visible {
   color: var(--washu-text-muted);
 }
 
+.match-faculty-text {
+  margin-top: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 10px;
+  background: var(--washu-page-strong);
+  color: var(--washu-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: "ui-monospace", SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  box-shadow: inset 0 2px 6px var(--washu-shadow-soft);
+}
+
 .match-empty {
   margin-top: 1rem;
   color: var(--washu-text-muted);
@@ -1108,6 +1123,12 @@ body[data-theme="dark"] .match-identifier-label {
 
 body[data-theme="dark"] .match-empty {
   color: #cbd5f5;
+}
+
+body[data-theme="dark"] .match-faculty-text {
+  background: #0b1120;
+  color: #e2e8f0;
+  box-shadow: inset 0 2px 10px rgba(2, 6, 23, 0.55);
 }
 
 body[data-theme="dark"] .prompt-preview {

--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -92,6 +92,7 @@ interface FacultyMatchResult {
   rowIndex: number;
   similarity: number;
   identifiers: Record<string, string>;
+  facultyText?: string;
 }
 
 interface PromptMatchResult {
@@ -2028,6 +2029,11 @@ function App() {
                                   </span>
                                 )}
                               </div>
+                              {faculty.facultyText && (
+                                <pre className="match-faculty-text">
+                                  {faculty.facultyText}
+                                </pre>
+                              )}
                             </li>
                           );
                         })}


### PR DESCRIPTION
## Summary
- add faculty_text details to match responses so single prompt/document requests can surface the underlying faculty description
- surface the faculty text in the React UI and style it for both light and dark themes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf0a4c19748325afc22a70e2e9b4e9