### PR TITLE
Support roster preview mapping in custom roster flows

### DIFF
--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -2885,6 +2885,11 @@ fn restore_default_faculty_dataset(
     fs::write(&destination, DEFAULT_FACULTY_DATASET)
         .map_err(|err| format!("Unable to restore the default faculty dataset: {err}"))?;
 
+    let embeddings_path = dataset_directory(&app_handle)?.join(FACULTY_EMBEDDINGS_NAME);
+    ensure_dataset_directory(&embeddings_path)?;
+    fs::write(&embeddings_path, DEFAULT_FACULTY_EMBEDDINGS)
+        .map_err(|err| format!("Unable to restore the default faculty embeddings: {err}"))?;
+
     let _ = clear_faculty_dataset_source_path(&app_handle);
 
     let mut status = build_faculty_dataset_status(&app_handle)?;

--- a/tauri-gui/src-tauri/src/lib.rs
+++ b/tauri-gui/src-tauri/src/lib.rs
@@ -70,6 +70,10 @@ struct SubmissionPayload {
     spreadsheet_prompt_columns: Vec<String>,
     #[serde(default)]
     spreadsheet_identifier_columns: Vec<String>,
+    #[serde(default)]
+    faculty_roster_column_map: HashMap<String, String>,
+    #[serde(default)]
+    faculty_roster_warnings: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -100,6 +104,8 @@ struct SubmissionDetails {
     prompt_preview: Option<String>,
     spreadsheet_prompt_columns: Vec<String>,
     spreadsheet_identifier_columns: Vec<String>,
+    faculty_roster_column_map: HashMap<String, String>,
+    faculty_roster_warnings: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -131,6 +137,14 @@ struct FacultyDatasetPreviewResponse {
     suggested_embedding_columns: Vec<usize>,
     suggested_identifier_columns: Vec<usize>,
     suggested_program_columns: Vec<usize>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct FacultyRosterPreviewResponse {
+    preview: SpreadsheetPreview,
+    suggested_identifier_matches: HashMap<String, Option<usize>>,
+    warnings: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -211,13 +225,15 @@ fn perform_matching_request(
         faculty_recs_per_student,
         spreadsheet_prompt_columns,
         spreadsheet_identifier_columns,
+        faculty_roster_column_map,
+        faculty_roster_warnings,
     } = payload;
 
     if faculty_recs_per_student == 0 {
         return Err("Specify at least one faculty recommendation per student.".into());
     }
 
-    let mut warnings = Vec::new();
+    let mut warnings = faculty_roster_warnings.clone();
     let mut validated_paths = Vec::new();
     let mut prompt_preview = None;
     let mut selected_prompt_columns = Vec::new();
@@ -226,6 +242,8 @@ fn perform_matching_request(
     let mut prepared_prompt_text: Option<String> = None;
     let mut directory_source: Option<PathBuf> = None;
     let mut spreadsheet_source: Option<PathBuf> = None;
+    let mut detail_roster_column_map: HashMap<String, String> = HashMap::new();
+    let mut roster_warning_messages = faculty_roster_warnings;
 
     match task_type {
         TaskType::Prompt => {
@@ -301,6 +319,196 @@ fn perform_matching_request(
         }
         faculty_roster_path = Some(roster.to_string_lossy().into_owned());
         validated_paths.push(PathConfirmation::new("Faculty list", &roster));
+
+        let metadata = load_faculty_dataset_metadata(&app_handle)?.ok_or_else(|| {
+            "The faculty dataset metadata is unavailable. Refresh the dataset analysis before limiting faculty by roster.".to_string()
+        })?;
+
+        let mut identifier_lookup: HashMap<String, String> = HashMap::new();
+        for identifier in &metadata.analysis.identifier_columns {
+            identifier_lookup.insert(identifier.trim().to_lowercase(), identifier.clone());
+        }
+
+        let mut resolved_map: HashMap<String, String> = HashMap::new();
+        for (raw_identifier, roster_label) in faculty_roster_column_map.iter() {
+            let normalized_identifier = raw_identifier.trim().to_lowercase();
+            if normalized_identifier.is_empty() {
+                continue;
+            }
+
+            let trimmed_label = roster_label.trim();
+            if trimmed_label.is_empty() {
+                continue;
+            }
+
+            if let Some(original_identifier) = identifier_lookup.get(&normalized_identifier) {
+                resolved_map
+                    .entry(original_identifier.clone())
+                    .or_insert_with(|| trimmed_label.to_string());
+            } else {
+                let message = format!(
+                    "The roster mapping includes an unknown identifier '{raw_identifier}'.",
+                );
+                warnings.push(message.clone());
+                roster_warning_messages.push(message);
+            }
+        }
+
+        if resolved_map.is_empty() {
+            return Err("Map at least one roster column to a faculty identifier.".into());
+        }
+
+        let (mut headers, mut rows) = read_full_spreadsheet(&roster)?;
+        align_row_lengths(&mut headers, &mut rows);
+
+        detail_roster_column_map = resolved_map.clone();
+
+        let header_map = build_header_index_map(&headers);
+        let mut roster_column_indexes: HashMap<String, usize> = HashMap::new();
+
+        for (identifier, roster_label) in resolved_map.iter() {
+            let normalized_label = roster_label.trim().to_lowercase();
+            let mut column_index = header_map.get(&normalized_label).copied();
+
+            if column_index.is_none() {
+                let normalized_target = normalize_identifier_label(roster_label);
+                if !normalized_target.is_empty() {
+                    for (candidate_index, header) in headers.iter().enumerate() {
+                        if normalize_identifier_label(header) == normalized_target {
+                            column_index = Some(candidate_index);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if let Some(found_index) = column_index {
+                roster_column_indexes.insert(identifier.clone(), found_index);
+            } else {
+                let message = format!(
+                    "The roster does not contain a column named '{roster_label}' for identifier '{identifier}'.",
+                );
+                warnings.push(message.clone());
+                roster_warning_messages.push(message);
+            }
+        }
+
+        if roster_column_indexes.is_empty() {
+            return Err(
+                "None of the mapped roster columns were found in the roster spreadsheet.".into(),
+            );
+        }
+
+        let identifier_order: Vec<String> = metadata
+            .analysis
+            .identifier_columns
+            .iter()
+            .filter(|identifier| roster_column_indexes.contains_key(*identifier))
+            .cloned()
+            .collect();
+
+        if identifier_order.is_empty() {
+            return Err("Map at least one roster column to a faculty identifier.".into());
+        }
+
+        let mut dataset_index: HashMap<String, HashSet<usize>> = HashMap::new();
+        for membership in &metadata.memberships {
+            let mut parts = Vec::new();
+            for identifier in &identifier_order {
+                if let Some(value) = membership.identifiers.get(identifier) {
+                    let normalized = normalize_identifier_value(value);
+                    if normalized.is_empty() {
+                        parts.clear();
+                        break;
+                    }
+                    parts.push(normalized);
+                } else {
+                    parts.clear();
+                    break;
+                }
+            }
+
+            if parts.is_empty() {
+                continue;
+            }
+
+            let key = parts.join("|");
+            dataset_index
+                .entry(key)
+                .or_default()
+                .insert(membership.row_index);
+        }
+
+        if dataset_index.is_empty() {
+            let message =
+                "No faculty dataset identifiers were available for the selected roster columns."
+                    .to_string();
+            warnings.push(message.clone());
+            roster_warning_messages.push(message);
+        }
+
+        let mut matched_rows: HashSet<usize> = HashSet::new();
+        let mut unmatched_roster_rows = 0usize;
+
+        for row in &rows {
+            let mut parts = Vec::new();
+            let mut row_missing = false;
+
+            for identifier in &identifier_order {
+                let column_index = match roster_column_indexes.get(identifier) {
+                    Some(index) => *index,
+                    None => {
+                        row_missing = true;
+                        break;
+                    }
+                };
+
+                let value = row
+                    .get(column_index)
+                    .map(|value| normalize_identifier_value(value));
+                match value {
+                    Some(normalized) if !normalized.is_empty() => parts.push(normalized),
+                    _ => {
+                        row_missing = true;
+                        break;
+                    }
+                }
+            }
+
+            if row_missing || parts.is_empty() {
+                unmatched_roster_rows += 1;
+                continue;
+            }
+
+            let key = parts.join("|");
+            if let Some(rows) = dataset_index.get(&key) {
+                matched_rows.extend(rows.iter().copied());
+            } else {
+                unmatched_roster_rows += 1;
+            }
+        }
+
+        if unmatched_roster_rows > 0 {
+            let message = format!(
+                "{unmatched_roster_rows} roster row{plural} did not match any faculty dataset entries.",
+                plural = if unmatched_roster_rows == 1 { "" } else { "s" }
+            );
+            warnings.push(message.clone());
+            roster_warning_messages.push(message);
+        }
+
+        if matched_rows.is_empty() {
+            let message =
+                "No faculty in the dataset matched the provided roster identifiers.".to_string();
+            warnings.push(message.clone());
+            roster_warning_messages.push(message);
+        }
+
+        for (identifier, &index) in &roster_column_indexes {
+            detail_roster_column_map.insert(identifier.clone(), header_label(&headers, index));
+        }
+
+        allowed_faculty_rows = Some(matched_rows);
     }
 
     if matches!(faculty_scope, FacultyScope::Program) && normalized_programs.is_empty() {
@@ -338,6 +546,8 @@ fn perform_matching_request(
         prompt_preview,
         spreadsheet_prompt_columns: selected_prompt_columns.clone(),
         spreadsheet_identifier_columns: detail_identifier_columns.clone(),
+        faculty_roster_column_map: detail_roster_column_map.clone(),
+        faculty_roster_warnings: roster_warning_messages.clone(),
     };
 
     let summary = build_summary(
@@ -2511,6 +2721,73 @@ fn get_faculty_dataset_status(
 }
 
 #[tauri::command]
+fn preview_faculty_roster(
+    app_handle: tauri::AppHandle,
+    path: String,
+) -> Result<FacultyRosterPreviewResponse, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("Provide a TSV, TXT, or Excel file to analyze for the faculty roster.".into());
+    }
+
+    let source = resolve_existing_path(Some(trimmed.to_string()), false, "Faculty roster file")?;
+    let (mut headers, mut rows) = read_spreadsheet_with_limit(&source, Some(10))?;
+    align_row_lengths(&mut headers, &mut rows);
+
+    let metadata = load_faculty_dataset_metadata(&app_handle)?.ok_or_else(|| {
+        "The faculty dataset metadata is unavailable. Refresh the dataset analysis before selecting a roster.".to_string()
+    })?;
+
+    let mut warnings = Vec::new();
+    let mut suggestions: HashMap<String, Option<usize>> = HashMap::new();
+
+    if metadata.analysis.identifier_columns.is_empty() {
+        warnings.push("No identifier columns are defined in the active faculty dataset.".into());
+    }
+
+    let header_map = build_header_index_map(&headers);
+
+    for identifier in &metadata.analysis.identifier_columns {
+        let normalized_identifier = identifier.trim().to_lowercase();
+        let mut column_index = header_map.get(&normalized_identifier).copied();
+
+        if column_index.is_none() {
+            let normalized_target = normalize_identifier_label(identifier);
+            if !normalized_target.is_empty() {
+                for (candidate_index, header) in headers.iter().enumerate() {
+                    if normalize_identifier_label(header) == normalized_target {
+                        column_index = Some(candidate_index);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some(index) = column_index {
+            suggestions.insert(identifier.clone(), Some(index));
+        } else {
+            warnings.push(format!(
+                "No roster column matched the faculty identifier '{identifier}'.",
+            ));
+            suggestions.insert(identifier.clone(), None);
+        }
+    }
+
+    let preview = SpreadsheetPreview {
+        headers,
+        rows,
+        suggested_prompt_columns: Vec::new(),
+        suggested_identifier_columns: Vec::new(),
+    };
+
+    Ok(FacultyRosterPreviewResponse {
+        preview,
+        suggested_identifier_matches: suggestions,
+        warnings,
+    })
+}
+
+#[tauri::command]
 fn preview_faculty_dataset_replacement(
     path: String,
 ) -> Result<FacultyDatasetPreviewResponse, String> {
@@ -2700,6 +2977,23 @@ fn normalize_columns(columns: Vec<String>) -> Vec<String> {
     }
 
     cleaned
+}
+
+fn normalize_identifier_value(value: &str) -> String {
+    value
+        .split_whitespace()
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn normalize_identifier_label(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .collect::<String>()
+        .to_lowercase()
 }
 
 fn read_spreadsheet(path: &Path) -> Result<(Vec<String>, Vec<Vec<String>>), String> {
@@ -3836,6 +4130,7 @@ pub fn run() {
             update_faculty_embeddings,
             analyze_spreadsheet,
             get_faculty_dataset_status,
+            preview_faculty_roster,
             preview_faculty_dataset_replacement,
             replace_faculty_dataset,
             restore_default_faculty_dataset,

--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -639,6 +639,9 @@ function App() {
         "restore_default_faculty_dataset",
       );
       applyDatasetStatus(status, "success");
+      if (status.isValid) {
+        await runEmbeddingRefresh(status);
+      }
     } catch (restoreError) {
       const message =
         restoreError instanceof Error

--- a/tauri-gui/src/App.tsx
+++ b/tauri-gui/src/App.tsx
@@ -60,6 +60,12 @@ interface FacultyDatasetPreviewResult {
   suggestedProgramColumns: number[];
 }
 
+interface FacultyRosterPreviewResult {
+  preview: SpreadsheetPreview;
+  suggestedIdentifierMatches: Record<string, number | null>;
+  warnings: string[];
+}
+
 interface FacultyDatasetStatus {
   path: string | null;
   canonicalPath: string | null;
@@ -85,6 +91,8 @@ interface SubmissionDetails {
   promptPreview?: string;
   spreadsheetPromptColumns: string[];
   spreadsheetIdentifierColumns: string[];
+  facultyRosterColumnMap: Record<string, string>;
+  facultyRosterWarnings: string[];
 }
 
 interface FacultyMatchResult {
@@ -252,6 +260,17 @@ function App() {
   const [customFacultyPath, setCustomFacultyPath] = useState("");
   const [facultyRecCount, setFacultyRecCount] = useState("10");
 
+  const [rosterPreview, setRosterPreview] =
+    useState<SpreadsheetPreview | null>(null);
+  const [rosterPreviewError, setRosterPreviewError] = useState<string | null>(
+    null,
+  );
+  const [isLoadingRosterPreview, setIsLoadingRosterPreview] = useState(false);
+  const [rosterIdentifierMapping, setRosterIdentifierMapping] = useState<
+    Record<string, number | null>
+  >({});
+  const [rosterWarnings, setRosterWarnings] = useState<string[]>([]);
+
   const [spreadsheetPreview, setSpreadsheetPreview] =
     useState<SpreadsheetPreview | null>(null);
   const [spreadsheetPreviewError, setSpreadsheetPreviewError] =
@@ -327,6 +346,14 @@ function App() {
     theme === "light"
       ? "Switch to dark WashU theme"
       : "Switch to light WashU theme";
+
+  const resetRosterConfiguration = useCallback(() => {
+    setRosterPreview(null);
+    setRosterPreviewError(null);
+    setIsLoadingRosterPreview(false);
+    setRosterIdentifierMapping({});
+    setRosterWarnings([]);
+  }, []);
 
   const applyDatasetStatus = useCallback(
     (
@@ -676,6 +703,7 @@ function App() {
 
     if (value !== "custom") {
       setCustomFacultyPath("");
+      resetRosterConfiguration();
     }
 
     if (value !== "program") {
@@ -720,11 +748,71 @@ function App() {
     }
   };
 
+  const handleRosterPathInput = (value: string) => {
+    setCustomFacultyPath(value);
+    setError(null);
+    setResult(null);
+    resetRosterConfiguration();
+  };
+
   const handleSpreadsheetPathInput = (value: string) => {
     setSpreadsheetPath(value);
     setError(null);
     setResult(null);
     resetSpreadsheetConfiguration();
+  };
+
+  const loadRosterPreview = async (path: string) => {
+    const trimmed = path.trim();
+    if (trimmed.length === 0) {
+      resetRosterConfiguration();
+      return;
+    }
+
+    setIsLoadingRosterPreview(true);
+    setRosterPreviewError(null);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await invoke<FacultyRosterPreviewResult>(
+        "preview_faculty_roster",
+        {
+          path: trimmed,
+        },
+      );
+
+      const mapping: Record<string, number | null> = {};
+      for (const [identifier, index] of Object.entries(
+        response.suggestedIdentifierMatches ?? {},
+      )) {
+        mapping[identifier] =
+          typeof index === "number" && Number.isInteger(index) ? index : null;
+      }
+
+      const datasetIdentifiers =
+        datasetStatus?.analysis?.identifierColumns ?? [];
+      for (const identifier of datasetIdentifiers) {
+        if (!(identifier in mapping)) {
+          mapping[identifier] = null;
+        }
+      }
+
+      setRosterPreview(response.preview);
+      setRosterWarnings(response.warnings ?? []);
+      setRosterIdentifierMapping(mapping);
+    } catch (analysisError) {
+      const message =
+        analysisError instanceof Error
+          ? analysisError.message
+          : String(analysisError);
+      setRosterPreview(null);
+      setRosterWarnings([]);
+      setRosterIdentifierMapping({});
+      setRosterPreviewError(message);
+    } finally {
+      setIsLoadingRosterPreview(false);
+    }
   };
 
   const loadSpreadsheetPreview = async (path: string) => {
@@ -768,6 +856,22 @@ function App() {
     }
   };
 
+  const handleRosterSelection = async () => {
+    const selection = await handleFileSelection(handleRosterPathInput, {
+      multiple: false,
+      filters: [
+        {
+          name: "Faculty rosters",
+          extensions: ["tsv", "txt", "xlsx", "xls"],
+        },
+      ],
+    });
+
+    if (selection) {
+      await loadRosterPreview(selection);
+    }
+  };
+
   const handleSpreadsheetSelection = async () => {
     const selection = await handleFileSelection(setSpreadsheetPath, {
       multiple: false,
@@ -782,6 +886,24 @@ function App() {
     if (selection) {
       await loadSpreadsheetPreview(selection);
     }
+  };
+
+  const handleRosterIdentifierSelection = (
+    identifier: string,
+    rawIndex: string,
+  ) => {
+    setRosterIdentifierMapping((current) => {
+      const updated: Record<string, number | null> = { ...current };
+      if (rawIndex === "") {
+        updated[identifier] = null;
+      } else {
+        const parsed = Number.parseInt(rawIndex, 10);
+        updated[identifier] = Number.isNaN(parsed) ? null : parsed;
+      }
+      return updated;
+    });
+    setError(null);
+    setResult(null);
   };
 
   const toggleIdentifierColumn = (index: number) => {
@@ -832,6 +954,45 @@ function App() {
     return unique
       .filter((index) => index < spreadsheetPreview.headers.length)
       .map((index) => getColumnLabel(index));
+  };
+
+  const getRosterColumnLabel = (index: number) => {
+    if (!rosterPreview) {
+      return `Column ${index + 1}`;
+    }
+
+    const header = rosterPreview.headers[index];
+    if (!header) {
+      return `Column ${index + 1}`;
+    }
+
+    const trimmed = header.trim();
+    return trimmed.length > 0 ? trimmed : `Column ${index + 1}`;
+  };
+
+  const mapRosterColumnSelection = (
+    mapping: Record<string, number | null>,
+  ): Record<string, string> => {
+    const entries: [string, string][] = [];
+
+    for (const [identifier, index] of Object.entries(mapping)) {
+      if (typeof index !== "number" || Number.isNaN(index)) {
+        continue;
+      }
+
+      if (!rosterPreview) {
+        entries.push([identifier, `Column ${index + 1}`]);
+        continue;
+      }
+
+      if (index < 0 || index >= rosterPreview.headers.length) {
+        continue;
+      }
+
+      entries.push([identifier, getRosterColumnLabel(index)]);
+    }
+
+    return Object.fromEntries(entries);
   };
 
   const getDatasetConfigurationColumnLabel = (index: number) => {
@@ -892,6 +1053,8 @@ function App() {
       1,
       Number.parseInt(facultyRecCount, 10) || 0,
     );
+    let rosterColumnMap: Record<string, string> = {};
+
     if (taskType === "spreadsheet") {
       const trimmedPath = spreadsheetPath.trim();
       if (trimmedPath.length === 0) {
@@ -908,6 +1071,30 @@ function App() {
 
       if (selectedPromptColumns.length === 0) {
         setError("Select at least one column containing the student prompts.");
+        setIsSubmitting(false);
+        return;
+      }
+    }
+
+    if (facultyScope === "custom") {
+      const trimmedRosterPath = customFacultyPath.trim();
+      if (trimmedRosterPath.length === 0) {
+        setError("Provide a faculty roster spreadsheet to limit the faculty list.");
+        setIsSubmitting(false);
+        return;
+      }
+
+      if (!rosterPreview) {
+        setError("Load the roster preview to map faculty identifiers before submitting.");
+        setIsSubmitting(false);
+        return;
+      }
+
+      rosterColumnMap = mapRosterColumnSelection(rosterIdentifierMapping);
+      if (Object.keys(rosterColumnMap).length === 0) {
+        setError(
+          "Select at least one roster column that corresponds to a faculty identifier.",
+        );
         setIsSubmitting(false);
         return;
       }
@@ -949,6 +1136,12 @@ function App() {
             spreadsheetIdentifierColumns:
               taskType === "spreadsheet"
                 ? mapSelectedColumns(selectedIdentifierColumns)
+                : undefined,
+            facultyRosterColumnMap:
+              facultyScope === "custom" ? rosterColumnMap : undefined,
+            facultyRosterWarnings:
+              facultyScope === "custom" && rosterWarnings.length > 0
+                ? rosterWarnings
                 : undefined,
           },
         },
@@ -1495,29 +1688,136 @@ function App() {
                   <button
                     type="button"
                     className="secondary"
-                    onClick={() =>
-                      handleFileSelection(setCustomFacultyPath, {
-                        multiple: false,
-                        filters: [
-                          {
-                            name: "Faculty rosters",
-                            extensions: ["tsv", "txt", "xlsx", "xls"],
-                          },
-                        ],
-                      })
-                    }
+                    onClick={() => void handleRosterSelection()}
                   >
                     Browse…
                   </button>
                   <input
                     type="text"
                     value={customFacultyPath}
-                    onChange={(event) => setCustomFacultyPath(event.target.value)}
+                    onChange={(event) =>
+                      handleRosterPathInput(event.target.value)
+                    }
                     placeholder="Paste or confirm the faculty roster path"
                   />
+                  <button
+                    type="button"
+                    onClick={() => void loadRosterPreview(customFacultyPath)}
+                    disabled={
+                      customFacultyPath.trim().length === 0 ||
+                      isLoadingRosterPreview
+                    }
+                  >
+                    {isLoadingRosterPreview
+                      ? "Loading preview…"
+                      : "Load roster preview"}
+                  </button>
                 </div>
                 {customFacultyPath && (
                   <div className="path-preview">{customFacultyPath}</div>
+                )}
+                {rosterPreviewError && (
+                  <div className="preview-error">{rosterPreviewError}</div>
+                )}
+                {isLoadingRosterPreview && !rosterPreviewError && (
+                  <div className="preview-status">
+                    Analyzing the roster…
+                  </div>
+                )}
+                {rosterWarnings.length > 0 && (
+                  <ul className="warning-list">
+                    {rosterWarnings.map((warning, index) => (
+                      <li key={`roster-warning-${index}`}>{warning}</li>
+                    ))}
+                  </ul>
+                )}
+                {rosterPreview && (
+                  <div className="spreadsheet-preview-card">
+                    <div className="column-selector-group">
+                      <div className="column-selector">
+                        <h4>Roster identifier mapping</h4>
+                        <p className="small-note">
+                          Match each dataset identifier column to the
+                          corresponding column in the roster. Only matched
+                          identifiers will be used to limit the faculty list.
+                        </p>
+                        {datasetStatus?.analysis?.identifierColumns &&
+                        datasetStatus.analysis.identifierColumns.length > 0 ? (
+                          <div className="column-checkbox-list">
+                            {datasetStatus.analysis.identifierColumns.map(
+                              (identifier) => {
+                                const selected =
+                                  rosterIdentifierMapping[identifier] ?? null;
+                                return (
+                                  <label
+                                    key={`roster-identifier-${identifier}`}
+                                    className="column-checkbox-option"
+                                  >
+                                    <span>{identifier}</span>
+                                    <select
+                                      value={
+                                        selected == null
+                                          ? ""
+                                          : String(selected)
+                                      }
+                                      onChange={(event) =>
+                                        handleRosterIdentifierSelection(
+                                          identifier,
+                                          event.target.value,
+                                        )
+                                      }
+                                    >
+                                      <option value="">No match</option>
+                                      {rosterPreview.headers.map((_, index) => (
+                                        <option
+                                          key={`roster-column-${identifier}-${index}`}
+                                          value={index}
+                                        >
+                                          {getRosterColumnLabel(index)}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </label>
+                                );
+                              },
+                            )}
+                          </div>
+                        ) : (
+                          <p className="small-note">
+                            No identifier columns were detected in the active
+                            faculty dataset.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <div className="preview-table-wrapper">
+                      <table className="preview-table">
+                        <thead>
+                          <tr>
+                            {rosterPreview.headers.map((_, index) => (
+                              <th key={`roster-header-${index}`}>
+                                {getRosterColumnLabel(index)}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {rosterPreview.rows.map((row, rowIndex) => (
+                            <tr key={`roster-row-${rowIndex}`}>
+                              {row.map((value, columnIndex) => (
+                                <td
+                                  key={`roster-cell-${rowIndex}-${columnIndex}`}
+                                  title={value}
+                                >
+                                  {value}
+                                </td>
+                              ))}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
                 )}
                 <p className="small-note">
                   Upload a tab-delimited TSV/TXT or Excel file listing the
@@ -1808,6 +2108,39 @@ function App() {
                         <div className="path-preview">
                           {result.details.customFacultyPath}
                         </div>
+                      </dd>
+                    </>
+                  )}
+                  {Object.keys(result.details.facultyRosterColumnMap).length >
+                    0 && (
+                    <>
+                      <dt>Roster mapping</dt>
+                      <dd>
+                        <ul className="path-list">
+                          {Object.entries(
+                            result.details.facultyRosterColumnMap,
+                          ).map(([identifier, column]) => (
+                            <li key={`roster-map-${identifier}-${column}`}>
+                              <strong>{identifier}:</strong> {column}
+                            </li>
+                          ))}
+                        </ul>
+                      </dd>
+                    </>
+                  )}
+                  {result.details.facultyRosterWarnings.length > 0 && (
+                    <>
+                      <dt>Roster warnings</dt>
+                      <dd>
+                        <ul className="warning-list">
+                          {result.details.facultyRosterWarnings.map(
+                            (warning, index) => (
+                              <li key={`roster-warning-detail-${index}`}>
+                                {warning}
+                              </li>
+                            ),
+                          )}
+                        </ul>
                       </dd>
                     </>
                   )}


### PR DESCRIPTION
## Summary
- add roster preview loading and identifier column mapping UI when using a custom faculty roster
- extend submission payloads/details and add a backend preview command so roster column mappings and warnings travel through the app
- intersect custom rosters with faculty dataset identifiers during submission, capturing unmatched-row warnings

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf1b2f7c688325aa285f9f69b9506a