### PR TITLE
Refocus README on in-app usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,38 @@
 # DDBS Reviewer Recommendations
 
-Desktop tooling for configuring student-to-faculty reviewer recommendations. The
-initial milestone delivers a Tauri-based interface that captures matching
-settings, validates inputs, and confirms which options would be submitted to the
-matching backend.
+The DDBS Reviewer Recommendations desktop app helps program coordinators pair students with appropriate faculty reviewers. It walks you through picking the right student list, narrowing the faculty pool, and confirming how many recommendations each student should receive. When you finish the form, the app presents a clear summary that can be shared with teammates who run the matching process.
 
-## Repository layout
+## When to use this app
+Use the app any time you need to collect or update reviewer assignments for an upcoming milestone or event. It is designed for non-technical staff who know:
 
-- `tauri-gui/` – Tauri + React application that hosts the configuration UI.
-- `tauri-gui/src-tauri/` – Rust commands that validate configuration requests.
+- Which students require reviewers.
+- Which faculty members are available for the current round.
+- How many reviewers each student should be matched with.
 
-## Getting started
+If the matching policy changes, you can adjust the selections inside the form without needing to edit any files.
 
-```bash
-cd tauri-gui
-npm install
-npm run tauri dev
-```
+## Guided workflow inside the app
+Once the app window is open, follow the on-screen form from top to bottom. Each section must be completed before you can continue.
 
-Use the form to select the student data source, constrain the faculty pool, and
-adjust recommendation limits. Submitting the form runs server-side validation in
-Rust; the UI displays the confirmation payload without executing any matching
-logic.
+1. **Select the student list** – Choose the source that contains the students needing reviewers. This may be a specific cohort, CSV upload, or another named list provided by your organization. The app highlights missing or incompatible choices so you can correct them before moving on.
+2. **Pick eligible faculty** – Indicate which faculty members should be considered. You can include or exclude groups (for example, by department or specialty) and the app will display how many faculty remain in the pool.
+3. **Set recommendation counts** – Decide how many reviewers each student should receive. Enter whole numbers only. If a number does not make sense (such as requesting more reviewers than available faculty), the form will prompt you to adjust it.
+4. **Review the confirmation panel** – The summary at the end shows every decision you made: the student list, selected faculty groups, and recommendation totals. No matching occurs yet—it is simply a record of the configuration you approved.
+
+You can go back to any previous section to make changes. The confirmation panel updates instantly so you can see the effect of your adjustments.
+
+## Sharing the results
+When you are satisfied with the confirmation panel:
+
+1. Copy the summary text or download any export the app provides.
+2. Share the configuration with the teammate or system that performs the actual reviewer matching.
+3. Let your team know about any special notes (for example, students who already have assigned reviewers) that are not captured by the form.
+
+Keeping a copy of each submission helps you compare rounds and answer questions later.
+
+## Troubleshooting while using the form
+- **A field is highlighted in red:** Read the message next to the field. It will tell you what needs to change (for example, "please choose at least one faculty group").
+- **The confirmation panel looks incomplete:** Scroll back through the form to ensure each section is marked complete. Missing selections will be outlined so you can spot them quickly.
+- **You are unsure which option to pick:** Check with your program's coordinator or refer to your internal reviewer assignment guidelines. The app enforces only the basics; your team's policies should guide the final choices.
+
+If you run into issues that the form cannot resolve, capture a screenshot of the error and share it with your technical support contact. They can make sure the app and underlying data remain up to date.


### PR DESCRIPTION
## Summary
- rewrite the README to emphasize what the reviewer recommendation app does for coordinators
- provide a guided walkthrough of the in-app workflow along with sharing and troubleshooting tips
- remove build and startup instructions to keep the document focused on day-to-day use

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68cf24d8ce048325b90b69f4a8cc642e