### PR TITLE
Add CI workflow for packaging and releases

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,95 @@
+name: Build and Release Tauri App
+
+on:
+  pull_request:
+    paths:
+      - 'tauri-gui/**'
+      - '.github/workflows/packaging.yml'
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    strategy:
+      matrix:
+        platform: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: tauri-gui/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: tauri-gui
+        run: npm ci
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Tauri application
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: tauri-gui
+          publish: false
+
+  create-release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    outputs:
+      release-id: ${{ steps.create-release.outputs.id }}
+    steps:
+      - name: Create GitHub release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: DDBS Reviewer Recommendations v${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+  release:
+    needs: create-release
+    if: startsWith(github.ref, 'refs/tags/')
+    strategy:
+      matrix:
+        platform: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: tauri-gui/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: tauri-gui
+        run: npm ci
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build and upload release artifacts
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: tauri-gui
+          releaseId: ${{ needs.create-release.outputs.release-id }}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Tauri app on Windows and macOS
- run packaging on every pull request without publishing artifacts
- create releases for tagged pushes and attach the platform builds

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68cf29998ef08325a868655548368a33