### PR TITLE
Limit Windows bundles to MSI

### DIFF
--- a/dbbs-faculty-match/src-tauri/tauri.windows.conf.json
+++ b/dbbs-faculty-match/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "targets": ["msi"]
+  }
+}


### PR DESCRIPTION
## Summary
- add a Windows-specific Tauri configuration override that restricts bundling to MSI installers so executable installers are no longer produced

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf4287f1d0832589667cdecf1485e1