### PR TITLE
Prune torch development assets from bundled runtime

### DIFF
--- a/dbbs-faculty-match/scripts/prepare-python.mjs
+++ b/dbbs-faculty-match/scripts/prepare-python.mjs
@@ -177,7 +177,9 @@ function pruneTorchPackage(sitePackagesDir) {
   const removals = [];
   const dropDirs = [
     path.join(torchDir, 'include'),
-    path.join(torchDir, 'share')
+    path.join(torchDir, 'share'),
+    path.join(torchDir, 'lib', 'cmake'),
+    path.join(torchDir, 'lib', 'pkgconfig')
   ];
 
   for (const dir of dropDirs) {
@@ -190,7 +192,8 @@ function pruneTorchPackage(sitePackagesDir) {
   const libDir = path.join(torchDir, 'lib');
   if (fs.existsSync(libDir)) {
     for (const entry of fs.readdirSync(libDir)) {
-      if (entry.toLowerCase().endsWith('.pdb')) {
+      const lower = entry.toLowerCase();
+      if (lower.endsWith('.pdb') || lower.endsWith('.lib') || lower.endsWith('.exp') || lower.endsWith('.ilk')) {
         fs.rmSync(path.join(libDir, entry), { force: true });
         removals.push(path.join('lib', entry));
       }


### PR DESCRIPTION
## Summary
- ensure the bundled Python environment is resolved even when reusing an existing runtime and fail if the interpreter is missing
- add helpers that locate the runtime's site-packages directory and remove torch headers, share metadata, and debug symbol files
- prune development-only torch assets every time prepare-python runs so the Windows MSI bundle has fewer files to link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00087c0688325898b36d97d0a6076