### PR TITLE
Ensure makensis is available in release workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -248,13 +248,63 @@ jobs:
         shell: pwsh
         run: |
           choco upgrade nsis -y --no-progress
+          $refresh = Join-Path $env:ChocolateyInstall 'bin/RefreshEnv.cmd'
+          if (Test-Path $refresh) {
+            & $refresh | Out-Null
+          }
+
+          $candidateDirs = @()
+          if ($env:ProgramFiles) {
+            $candidateDirs += (Join-Path $env:ProgramFiles 'NSIS')
+          }
+          if (${env:ProgramFiles(x86)}) {
+            $candidateDirs += (Join-Path ${env:ProgramFiles(x86)} 'NSIS')
+          }
+          if ($env:ChocolateyInstall) {
+            $candidateDirs += Get-ChildItem -Path (Join-Path $env:ChocolateyInstall 'lib') -Directory -Filter 'nsis*' |
+              Sort-Object LastWriteTime -Descending |
+              ForEach-Object { Join-Path $_.FullName 'tools' }
+          }
+
+          foreach ($dir in $candidateDirs | Where-Object { $_ -and (Test-Path $_) }) {
+            if (Test-Path (Join-Path $dir 'makensis.exe')) {
+              $dir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+              Write-Host "Added $dir to PATH"
+              break
+            }
+          }
 
       - name: Verify makensis works
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Get-Command makensis
-          makensis /VERSION
+          $command = Get-Command makensis -ErrorAction SilentlyContinue
+          if (-not $command) {
+            $candidates = @()
+            if ($env:ProgramFiles) {
+              $candidates += (Join-Path $env:ProgramFiles 'NSIS/makensis.exe')
+            }
+            if (${env:ProgramFiles(x86)}) {
+              $candidates += (Join-Path ${env:ProgramFiles(x86)} 'NSIS/makensis.exe')
+            }
+            if ($env:ChocolateyInstall) {
+              $candidates += Get-ChildItem -Path (Join-Path $env:ChocolateyInstall 'lib') -Directory -Filter 'nsis*' |
+                Sort-Object LastWriteTime -Descending |
+                ForEach-Object { Join-Path $_.FullName 'tools/makensis.exe' }
+            }
+
+            foreach ($candidate in $candidates | Where-Object { $_ -and (Test-Path $_) }) {
+              $command = Get-Item $candidate
+              break
+            }
+          }
+
+          if (-not $command) {
+            throw 'makensis executable not found after installing NSIS'
+          }
+
+          $exePath = if ($command -is [System.Management.Automation.CommandInfo]) { $command.Source } else { $command.FullName }
+          & $exePath /VERSION
 
       - name: Build Tauri application
         working-directory: dbbs-faculty-match
@@ -263,14 +313,36 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
 
-      - name: Rename Windows installer
+      - name: Locate and rename Windows installer
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $bundleDir = if ($env:CARGO_TARGET_DIR) { Join-Path $env:CARGO_TARGET_DIR 'release\bundle\nsis' } else { 'dbbs-faculty-match\src-tauri\target\release\bundle\nsis' }
-          if (-not (Test-Path $bundleDir)) { throw "Bundle directory not found: $bundleDir" }
-          $installer = Get-ChildItem -Path $bundleDir -Filter '*.exe' | Select-Object -First 1
-          if (-not $installer) { throw "NSIS installer not found in $bundleDir" }
+          $bundleRoots = @()
+          if ($env:CARGO_TARGET_DIR) {
+            $bundleRoots += (Join-Path $env:CARGO_TARGET_DIR 'release\bundle')
+          }
+          $bundleRoots += 'dbbs-faculty-match\src-tauri\target\release\bundle'
+
+          $installer = $null
+          foreach ($root in $bundleRoots) {
+            if (-not $root) { continue }
+            if (-not (Test-Path $root)) { continue }
+
+            $nsisDir = Join-Path $root 'nsis'
+            if (Test-Path $nsisDir) {
+              $installer = Get-ChildItem -Path $nsisDir -Filter '*.exe' -File -ErrorAction SilentlyContinue | Select-Object -First 1
+            }
+
+            if (-not $installer) {
+              $installer = Get-ChildItem -Path $root -Filter '*.exe' -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+            }
+
+            if ($installer) { break }
+          }
+
+          if (-not $installer) {
+            throw "NSIS installer not found in bundle directories. Checked: $($bundleRoots -join ', ')"
+          }
           $newName = "${{ steps.metadata.outputs.slug }}_${{ steps.metadata.outputs.version }}_${{ matrix.artifact-suffix }}.exe"
           Rename-Item -Path $installer.FullName -NewName $newName -Force
 
@@ -296,12 +368,34 @@ jobs:
           RELEASE_TAG: ${{ needs.create-release.outputs.release-tag }}
         run: |
           set -euo pipefail
-          base_dir="dbbs-faculty-match/src-tauri/target/release/bundle"
-          if [[ ! -d "$base_dir" ]]; then
-            echo "Bundle directory not found: $base_dir" >&2
+          bundle_dirs=()
+          if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+            bundle_dir="${CARGO_TARGET_DIR}/release/bundle"
+            if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+              bundle_dir="$(cygpath -u "$bundle_dir" 2>/dev/null || echo "$bundle_dir")"
+            fi
+            bundle_dirs+=("$bundle_dir")
+          fi
+
+          default_dir='dbbs-faculty-match/src-tauri/target/release/bundle'
+          if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+            default_dir="$(cygpath -u "$default_dir" 2>/dev/null || echo "$default_dir")"
+          fi
+          bundle_dirs+=("$default_dir")
+
+          found_any=0
+          for dir in "${bundle_dirs[@]}"; do
+            if [[ ! -d "$dir" ]]; then
+              continue
+            fi
+            found_any=1
+            while IFS= read -r -d '' file; do
+              echo "Uploading $file"
+              gh release upload "$RELEASE_TAG" "$file" --clobber
+            done < <(find "$dir" -type f \( -name '*.exe' -o -name '*.zip' -o -name '*.dmg' -o -name '*.pkg' -o -name '*.app' -o -name '*.tar.gz' -o -name '*.msix' -o -name '*.json' \) -print0)
+          done
+
+          if [[ $found_any -eq 0 ]]; then
+            echo "Bundle directory not found. Checked: ${bundle_dirs[*]}" >&2
             exit 1
           fi
-          while IFS= read -r -d '' file; do
-            echo "Uploading $file"
-            gh release upload "$RELEASE_TAG" "$file" --clobber
-          done < <(find "$base_dir" -type f \( -name '*.exe' -o -name '*.zip' -o -name '*.dmg' -o -name '*.pkg' -o -name '*.app' -o -name '*.tar.gz' -o -name '*.msix' -o -name '*.json' \) -print0)


### PR DESCRIPTION
## Summary
- refresh the Windows environment after installing NSIS during release builds
- search for makensis installations and add them to PATH before verification
- fall back to directly invoking makensis.exe when Get-Command cannot find it
- locate NSIS bundle outputs from either the Cargo target directory or the default Tauri path before renaming and uploading installers

## Testing
- not run (CI workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68d07dcfeb2883258d0ca441886cc13a