### PR TITLE
Default to dark theme and improve dataset initialization

### DIFF
--- a/dbbs-faculty-match/index.html
+++ b/dbbs-faculty-match/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
@@ -7,7 +7,7 @@
     <title>Tauri + React + Typescript</title>
   </head>
 
-  <body>
+  <body data-theme="dark">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/dbbs-faculty-match/src/App.tsx
+++ b/dbbs-faculty-match/src/App.tsx
@@ -133,7 +133,7 @@ interface EmbeddingProgressPayload {
   estimatedRemainingSeconds?: number | null;
 }
 
-const THEME_STORAGE_KEY = "washu-theme";
+export const THEME_STORAGE_KEY = "washu-theme";
 
 const getStoredThemePreference = (): ThemePreference => {
   if (typeof window === "undefined") {
@@ -145,7 +145,7 @@ const getStoredThemePreference = (): ThemePreference => {
     return stored;
   }
 
-  return "light";
+  return "dark";
 };
 
 const formatDuration = (valueInSeconds: number): string => {

--- a/dbbs-faculty-match/src/main.tsx
+++ b/dbbs-faculty-match/src/main.tsx
@@ -1,6 +1,28 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
+import App, { THEME_STORAGE_KEY } from "./App";
+
+const applyInitialThemePreference = () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  let initialTheme: "light" | "dark" = "dark";
+
+  if (typeof window !== "undefined") {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") {
+      initialTheme = stored;
+    }
+  }
+
+  document.documentElement.dataset.theme = initialTheme;
+  if (document.body) {
+    document.body.dataset.theme = initialTheme;
+  }
+};
+
+applyInitialThemePreference();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- default to the dark theme when no stored preference is available and apply the choice before React mounts
- seed the faculty dataset with the packaged default automatically when no file exists and reuse the helper for manual resets
- capture the embedding helper's stdout/stderr when early I/O failures occur so stack traces are included in the error message

## Testing
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml *(fails: missing system library `glib-2.0` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1629431008325a97325a6661cff46