### PR TITLE
Add selectable Hugging Face embedding models

### DIFF
--- a/dbbs-faculty-match/src/App.css
+++ b/dbbs-faculty-match/src/App.css
@@ -575,6 +575,33 @@ button.theme-toggle:focus-visible {
   word-break: break-word;
 }
 
+.embedding-model-selector {
+  margin-top: 1.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.embedding-model-selector label {
+  font-weight: 600;
+  color: var(--washu-heading);
+}
+
+.embedding-model-selector select {
+  border-radius: 12px;
+  border: 1px solid var(--washu-border);
+  background: var(--washu-surface);
+  color: var(--washu-text);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.embedding-model-selector select:focus {
+  outline: none;
+  border-color: var(--washu-primary);
+  box-shadow: 0 0 0 3px var(--washu-focus-ring);
+}
+
 .dataset-path {
   font-family: "ui-monospace", SFMono-Regular, Menlo, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;


### PR DESCRIPTION
## Summary
- add a configurable embedding model selector in the UI alongside the dataset summary
- plumb the selected model through the embedding refresh flow and dataset status reporting
- generalize the Python embedding helper messaging for arbitrary Hugging Face checkpoints

## Testing
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml *(fails: system library `glib-2.0` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d19e113824832590d9102e97ead462