### PR TITLE
Switch Windows bundling to CPython embeddable runtime

### DIFF
--- a/dbbs-faculty-match/README.md
+++ b/dbbs-faculty-match/README.md
@@ -34,20 +34,30 @@ referenced files and directories exist before the matching backend is wired in.
    ```
 
 4. (Optional) Prepare the embedded Python runtime that ships with the desktop
-   installers. This step requires Python **3.11** to be installed and available
-   on your `PATH`, runs automatically during `tauri build`, and can be invoked
-   manually to verify dependency installation:
+   installers. The build now vendors the official CPython **3.11** embeddable
+   distribution on Windows and reuses virtual environments on macOS/Linux. The
+   script runs automatically during `tauri build` and can be invoked manually to
+   verify that the dependencies and Python payload are staged correctly:
 
    ```bash
    npm run prepare-python
    ```
 
-The `prepare-python` script creates an isolated virtual environment under
-`src-tauri/resources/python/<platform>-<arch>` and installs the packages needed
-to generate embeddings (`torch`, `transformers`, and their dependencies). The
-runtime currently pins `torch==2.2.2` and `transformers==4.56.2`, the newest
-versions that ship wheels for every platform we target with Python 3.11. The
-Tauri bundler copies these resources into the platform-specific installer so
+On Windows the script:
+
+1. Looks for vendored dependencies under
+   `python/vendor/windows-x86_64/site-packages` (populate this directory from a
+   Windows virtual environment that matches Python 3.11 x86_64).
+2. Downloads (or reuses) the official `python-3.11.9-embed-amd64.zip` archive
+   and extracts it into `src-tauri/resources/python/`.
+3. Enables `site-packages` via `python311._pth` and copies the contents of
+   `python/app` next to the interpreter as your application payload.
+
+macOS and Linux builds continue to create an isolated virtual environment under
+`src-tauri/resources/python/<platform>-<arch>` using the Python 3.11 interpreter
+available on your machine. In all cases the packaged runtime is self-contained,
+bundles the dependencies required for embedding generation (currently
+`torch==2.2.2` and `transformers==4.56.2`), and ships with the installer so end
 users do not need a system-wide Python installation.
 
 The form displays a confirmation payload after validation so that you can review

--- a/dbbs-faculty-match/package-lock.json
+++ b/dbbs-faculty-match/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "adm-zip": "^0.5.16",
         "typescript": "~5.8.3",
         "vite": "^7.0.4"
       }
@@ -1434,6 +1435,16 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/baseline-browser-mapping": {

--- a/dbbs-faculty-match/package.json
+++ b/dbbs-faculty-match/package.json
@@ -22,6 +22,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "adm-zip": "^0.5.16",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
   }

--- a/dbbs-faculty-match/python/app/README.md
+++ b/dbbs-faculty-match/python/app/README.md
@@ -1,0 +1,7 @@
+# Python application payload
+
+Place the Python entry point(s) that should ship with the desktop build in this
+directory. Files in this folder are copied into
+`src-tauri/resources/python/app` alongside the embeddable interpreter. Use
+relative paths from your Python code to access any additional assets you place
+here.

--- a/dbbs-faculty-match/python/vendor/README.md
+++ b/dbbs-faculty-match/python/vendor/README.md
@@ -1,0 +1,6 @@
+# Vendored Python packages
+
+This directory stores the site-packages trees that are bundled with the
+application. Populate the subdirectory that matches the platform you are
+packaging (for example `windows-x86_64/site-packages`). The contents are copied
+verbatim into the embeddable Python runtime during `npm run prepare-python`.

--- a/dbbs-faculty-match/python/vendor/windows-x86_64/README.md
+++ b/dbbs-faculty-match/python/vendor/windows-x86_64/README.md
@@ -1,0 +1,11 @@
+# Windows vendored packages
+
+Place the Windows (x86_64) Python site-packages tree in this directory. You can
+build it on a Windows development machine by installing the dependencies into a
+virtual environment and copying its `Lib/site-packages` folder here. Make sure
+all wheels are compatible with Python 3.11 and the 64-bit embeddable
+interpreter.
+
+If you download the official CPython embeddable distribution manually, the ZIP
+file can also be saved in this directory as `python-3.11.9-embed-amd64.zip` so
+that `npm run prepare-python` can reuse it without fetching it again.

--- a/dbbs-faculty-match/scripts/prepare-python.mjs
+++ b/dbbs-faculty-match/scripts/prepare-python.mjs
@@ -1,15 +1,24 @@
 import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import https from 'node:https';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import AdmZip from 'adm-zip';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..');
 const srcTauriDir = path.join(projectRoot, 'src-tauri');
 const resourcesDir = path.join(srcTauriDir, 'resources');
+const pythonRootDir = path.join(resourcesDir, 'python');
 const requirementsPath = path.join(projectRoot, 'python', 'requirements.txt');
+const vendorRoot = path.join(projectRoot, 'python', 'vendor');
+const appSourceDir = path.join(projectRoot, 'python', 'app');
+
+const PYTHON_VERSION = '3.11.9';
+const EMBEDDABLE_FILENAME = `python-${PYTHON_VERSION}-embed-amd64.zip`;
+const EMBEDDABLE_URL = `https://www.python.org/ftp/python/${PYTHON_VERSION}/${EMBEDDABLE_FILENAME}`;
 
 const platformMap = {
   win32: 'windows',
@@ -22,32 +31,22 @@ const archMap = {
   arm64: 'aarch64'
 };
 
-function fail(message) {
+function fail(message, error) {
+  if (error) {
+    console.error(error);
+  }
   console.error(`\u274c ${message}`);
   process.exit(1);
 }
 
-if (!fs.existsSync(requirementsPath)) {
-  fail(`Missing requirements file: ${requirementsPath}`);
-}
-
-const platform = platformMap[process.platform];
-if (!platform) {
-  fail(`Unsupported platform for bundling Python runtime: ${process.platform}`);
-}
-
-const arch = archMap[process.arch];
-if (!arch) {
-  fail(`Unsupported architecture for bundling Python runtime: ${process.arch}`);
-}
-
-const runtimeDirName = `${platform}-${arch}`;
-const pythonRootDir = path.join(resourcesDir, 'python');
-const runtimeDir = path.join(pythonRootDir, runtimeDirName);
-const metadataPath = path.join(runtimeDir, '.bundle-metadata.json');
-
 function ensureDirectory(dir) {
   fs.mkdirSync(dir, { recursive: true });
+}
+
+function removeDirectoryIfExists(targetPath) {
+  if (fs.existsSync(targetPath)) {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+  }
 }
 
 function hashFile(filePath) {
@@ -57,6 +56,9 @@ function hashFile(filePath) {
 }
 
 function removePythonBytecode(rootDir) {
+  if (!fs.existsSync(rootDir)) {
+    return;
+  }
   const entries = fs.readdirSync(rootDir, { withFileTypes: true });
   for (const entry of entries) {
     const entryPath = path.join(rootDir, entry.name);
@@ -72,75 +74,54 @@ function removePythonBytecode(rootDir) {
   }
 }
 
-function removeDirectoryIfExists(targetPath) {
-  if (fs.existsSync(targetPath)) {
-    fs.rmSync(targetPath, { recursive: true, force: true });
+function copyDirectoryContents(source, destination) {
+  if (!fs.existsSync(source)) {
+    return false;
   }
-}
 
-function pruneBundledRuntime(rootDir) {
-  const sitePackagesCandidates = [
-    path.join(rootDir, 'Lib', 'site-packages'),
-    path.join(rootDir, 'lib', 'python3.11', 'site-packages')
-  ];
-
-  for (const sitePackages of sitePackagesCandidates) {
-    if (!fs.existsSync(sitePackages)) {
-      continue;
-    }
-
-    const torchDir = path.join(sitePackages, 'torch');
-    if (fs.existsSync(torchDir)) {
-      const includeDir = path.join(torchDir, 'include');
-      if (fs.existsSync(includeDir)) {
-        console.log(
-          '\u2139\ufe0f Removing torch C++ headers from bundled runtime to keep Windows paths short.'
-        );
-        removeDirectoryIfExists(includeDir);
+  ensureDirectory(destination);
+  const entries = fs.readdirSync(source, { withFileTypes: true });
+  for (const entry of entries) {
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectoryContents(sourcePath, destinationPath);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(sourcePath, destinationPath);
+    } else if (entry.isSymbolicLink()) {
+      const target = fs.readlinkSync(sourcePath);
+      try {
+        fs.symlinkSync(target, destinationPath);
+      } catch (error) {
+        if (error.code === 'EEXIST') {
+          fs.rmSync(destinationPath);
+          fs.symlinkSync(target, destinationPath);
+        } else {
+          throw error;
+        }
       }
     }
   }
+
+  return true;
 }
 
-const requirementsHash = hashFile(requirementsPath);
-let reuseExisting = false;
+function pruneTorchHeaders(sitePackagesDir) {
+  const torchDir = path.join(sitePackagesDir, 'torch');
+  if (!fs.existsSync(torchDir)) {
+    return;
+  }
 
-if (fs.existsSync(metadataPath)) {
-  try {
-    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-    if (
-      metadata.requirementsHash === requirementsHash &&
-      typeof metadata.pythonVersion === 'string' &&
-      metadata.pythonVersion.startsWith('3.11.')
-    ) {
-      reuseExisting = true;
-      console.log(`\u2705 Bundled Python runtime for ${runtimeDirName} is up to date.`);
-    } else {
-      console.log(
-        `\u2139\ufe0f Runtime metadata changed; rebuilding bundled Python runtime for ${runtimeDirName}.`
-      );
-    }
-  } catch (error) {
-    console.warn(`\u26a0\ufe0f Unable to parse ${metadataPath}; rebuilding runtime.`);
+  const includeDir = path.join(torchDir, 'include');
+  if (fs.existsSync(includeDir)) {
+    console.log('\u2139\ufe0f Removing torch C++ headers from bundled runtime to keep Windows paths short.');
+    removeDirectoryIfExists(includeDir);
   }
 }
 
-function runCommand(command, args, options = {}) {
-  const result = spawnSync(command, args, {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      PIP_DISABLE_PIP_VERSION_CHECK: '1',
-      ...options.env
-    },
-    shell: options.shell ?? false
-  });
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(' ')} exited with status ${result.status}`);
-  }
+function writeMetadata(runtimeDir, metadata) {
+  const metadataPath = path.join(runtimeDir, '.bundle-metadata.json');
+  fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
 }
 
 function findPythonCandidate() {
@@ -181,7 +162,7 @@ function findPythonCandidate() {
 
 function resolveRuntimePython(runtimePath) {
   const candidates = process.platform === 'win32'
-    ? [path.join(runtimePath, 'Scripts', 'python.exe'), path.join(runtimePath, 'Scripts', 'python')] 
+    ? [path.join(runtimePath, 'Scripts', 'python.exe'), path.join(runtimePath, 'Scripts', 'python')]
     : [path.join(runtimePath, 'bin', 'python3'), path.join(runtimePath, 'bin', 'python')];
 
   for (const candidate of candidates) {
@@ -193,56 +174,279 @@ function resolveRuntimePython(runtimePath) {
   return null;
 }
 
-if (!reuseExisting) {
-  ensureDirectory(pythonRootDir);
-  if (fs.existsSync(runtimeDir)) {
-    fs.rmSync(runtimeDir, { recursive: true, force: true });
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      PIP_DISABLE_PIP_VERSION_CHECK: '1',
+      ...options.env
+    },
+    shell: options.shell ?? false
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} exited with status ${result.status}`);
+  }
+}
+
+function pythonIdentifier() {
+  const major = PYTHON_VERSION.split('.')[0];
+  const minor = PYTHON_VERSION.split('.')[1];
+  return `${major}${minor}`;
+}
+
+function configureEmbeddablePaths(runtimeDir) {
+  const identifier = pythonIdentifier();
+  const pthPath = path.join(runtimeDir, `python${identifier}._pth`);
+  const lines = [
+    `python${identifier}.zip`,
+    '.\\Lib',
+    '.\\DLLs',
+    '.\\site-packages',
+    '.\\app',
+    'import site'
+  ];
+  fs.writeFileSync(pthPath, lines.join('\r\n'));
+}
+
+function readDirectoryOrNull(dir) {
+  if (!fs.existsSync(dir)) {
+    return null;
+  }
+  return fs.readdirSync(dir);
+}
+
+async function downloadFile(url, destination) {
+  await new Promise((resolve, reject) => {
+    const request = https.get(url, response => {
+      if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+        const redirectedUrl = new URL(response.headers.location, url).toString();
+        downloadFile(redirectedUrl, destination).then(resolve).catch(reject);
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        reject(new Error(`Download failed with status ${response.statusCode}`));
+        return;
+      }
+
+      ensureDirectory(path.dirname(destination));
+      const fileStream = fs.createWriteStream(destination);
+      response.pipe(fileStream);
+      fileStream.on('finish', () => {
+        fileStream.close(resolve);
+      });
+      fileStream.on('error', reject);
+    });
+
+    request.on('error', reject);
+  });
+}
+
+async function resolveEmbeddableArchive() {
+  const windowsVendorDir = path.join(vendorRoot, 'windows-x86_64');
+  const vendoredArchive = path.join(windowsVendorDir, EMBEDDABLE_FILENAME);
+  if (fs.existsSync(vendoredArchive)) {
+    return vendoredArchive;
   }
 
-  const python = findPythonCandidate();
-  if (!python) {
+  const downloadDir = path.join(projectRoot, 'python', '.downloads');
+  const downloadPath = path.join(downloadDir, EMBEDDABLE_FILENAME);
+  if (fs.existsSync(downloadPath)) {
+    return downloadPath;
+  }
+
+  console.log(`\u2139\ufe0f Downloading Windows embeddable Python ${PYTHON_VERSION}...`);
+  try {
+    await downloadFile(EMBEDDABLE_URL, downloadPath);
+    return downloadPath;
+  } catch (error) {
+    console.warn('\u26a0\ufe0f Failed to download the embeddable distribution automatically.');
+    throw error;
+  }
+}
+
+async function prepareWindowsEmbeddable() {
+  console.log('\u2139\ufe0f Preparing Windows embeddable Python runtime.');
+
+  const requirementsHash = hashFile(requirementsPath);
+  const sitePackagesSource = path.join(vendorRoot, 'windows-x86_64', 'site-packages');
+  if (!fs.existsSync(sitePackagesSource)) {
     fail(
-      'Unable to locate a Python 3.11 interpreter to create the bundled runtime. Install Python 3.11 and ensure it is on your PATH.'
+      'Missing vendored Windows site-packages at python/vendor/windows-x86_64/site-packages. Populate this directory with the dependencies built for Python 3.11 x86_64.'
     );
   }
 
-  console.log(`\u2139\ufe0f Using ${python.command} to create bundled Python runtime at ${runtimeDir}.`);
-
-  runCommand(python.command, [...python.args, '-m', 'venv', runtimeDir]);
-
-  const runtimePython = resolveRuntimePython(runtimeDir);
-  if (!runtimePython) {
-    fail(`Virtual environment creation succeeded but no interpreter was found in ${runtimeDir}.`);
+  const appEntries = readDirectoryOrNull(appSourceDir);
+  if (!appEntries || appEntries.length === 0) {
+    console.log('\u26a0\ufe0f No Python application files found under python/app. A placeholder directory will be bundled.');
   }
 
-  console.log('\u2139\ufe0f Upgrading pip and installing dependencies for bundled Python runtime.');
-  runCommand(runtimePython, ['-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools', 'wheel']);
-  runCommand(runtimePython, ['-m', 'pip', 'install', '--no-cache-dir', '-r', requirementsPath]);
+  removeDirectoryIfExists(pythonRootDir);
+  ensureDirectory(pythonRootDir);
 
-  const versionResult = spawnSync(
-    runtimePython,
-    ['-c', 'import sys; print(".".join(map(str, sys.version_info[:3])))'],
-    {
-      stdio: ['ignore', 'pipe', 'inherit']
-    }
-  );
-  if (versionResult.status !== 0) {
-    fail('Unable to determine the Python version for the bundled runtime.');
+  let archivePath;
+  try {
+    archivePath = await resolveEmbeddableArchive();
+    console.log(`\u2139\ufe0f Using embeddable archive: ${archivePath}`);
+  } catch (error) {
+    fail(
+      `Unable to obtain the embeddable distribution automatically. Download ${EMBEDDABLE_FILENAME} from https://www.python.org/ftp/python/${PYTHON_VERSION}/ and place it in python/vendor/windows-x86_64 before retrying.`,
+      error
+    );
   }
 
-  const metadata = {
+  try {
+    const zip = new AdmZip(archivePath);
+    zip.extractAllTo(pythonRootDir, true);
+  } catch (error) {
+    fail('Unable to extract the embeddable Python archive.', error);
+  }
+
+  configureEmbeddablePaths(pythonRootDir);
+
+  const sitePackagesDestination = path.join(pythonRootDir, 'site-packages');
+  removeDirectoryIfExists(sitePackagesDestination);
+  ensureDirectory(sitePackagesDestination);
+  copyDirectoryContents(sitePackagesSource, sitePackagesDestination);
+
+  const appDestination = path.join(pythonRootDir, 'app');
+  removeDirectoryIfExists(appDestination);
+  if (appEntries && appEntries.length > 0) {
+    ensureDirectory(appDestination);
+    copyDirectoryContents(appSourceDir, appDestination);
+  } else {
+    ensureDirectory(appDestination);
+  }
+
+  pruneTorchHeaders(sitePackagesDestination);
+  removePythonBytecode(pythonRootDir);
+
+  writeMetadata(pythonRootDir, {
+    bundler: 'embeddable',
+    platform: 'windows',
+    arch: 'x86_64',
+    pythonVersion: PYTHON_VERSION,
     requirementsHash,
-    createdAt: new Date().toISOString(),
-    platform,
-    arch,
-    pythonVersion: versionResult.stdout?.toString().trim()
-  };
-  fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
-  console.log(`\u2705 Bundled Python runtime prepared for ${runtimeDirName}.`);
+    embeddableArchive: path.basename(archivePath),
+    updatedAt: new Date().toISOString()
+  });
+
+  console.log('\u2705 Bundled Windows embeddable Python runtime is ready.');
 }
 
-if (fs.existsSync(runtimeDir)) {
-  console.log('\u2139\ufe0f Removing Python bytecode caches from bundled runtime to avoid long Windows paths.');
-  removePythonBytecode(runtimeDir);
-  pruneBundledRuntime(runtimeDir);
+function preparePosixVirtualEnv(platform, arch) {
+  const requirementsHash = hashFile(requirementsPath);
+  const runtimeDir = path.join(pythonRootDir, `${platform}-${arch}`);
+  const metadataPath = path.join(runtimeDir, '.bundle-metadata.json');
+  let reuseExisting = false;
+
+  if (fs.existsSync(metadataPath)) {
+    try {
+      const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+      if (
+        metadata.requirementsHash === requirementsHash &&
+        typeof metadata.pythonVersion === 'string' &&
+        metadata.pythonVersion.startsWith('3.11.')
+      ) {
+        reuseExisting = true;
+        console.log(`\u2705 Bundled Python runtime for ${platform}-${arch} is up to date.`);
+      } else {
+        console.log(
+          `\u2139\ufe0f Runtime metadata changed; rebuilding bundled Python runtime for ${platform}-${arch}.`
+        );
+      }
+    } catch (error) {
+      console.warn(
+        '\u26a0\ufe0f Unable to parse existing runtime metadata; rebuilding bundled Python runtime.'
+      );
+    }
+  }
+
+  if (!reuseExisting) {
+    ensureDirectory(pythonRootDir);
+    if (fs.existsSync(runtimeDir)) {
+      fs.rmSync(runtimeDir, { recursive: true, force: true });
+    }
+
+    const python = findPythonCandidate();
+    if (!python) {
+      fail(
+        'Unable to locate a Python 3.11 interpreter to create the bundled runtime. Install Python 3.11 and ensure it is on your PATH.'
+      );
+    }
+
+    console.log(`\u2139\ufe0f Using ${python.command} to create bundled Python runtime at ${runtimeDir}.`);
+
+    runCommand(python.command, [...python.args, '-m', 'venv', runtimeDir]);
+
+    const runtimePython = resolveRuntimePython(runtimeDir);
+    if (!runtimePython) {
+      fail(`Virtual environment creation succeeded but no interpreter was found in ${runtimeDir}.`);
+    }
+
+    console.log('\u2139\ufe0f Upgrading pip and installing dependencies for bundled Python runtime.');
+    runCommand(runtimePython, ['-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools', 'wheel']);
+    runCommand(runtimePython, ['-m', 'pip', 'install', '--no-cache-dir', '-r', requirementsPath]);
+
+    const versionResult = spawnSync(
+      runtimePython,
+      ['-c', 'import sys; print(".".join(map(str, sys.version_info[:3])))'],
+      {
+        stdio: ['ignore', 'pipe', 'inherit']
+      }
+    );
+    if (versionResult.status !== 0) {
+      fail('Unable to determine the Python version for the bundled runtime.');
+    }
+
+    const metadata = {
+      requirementsHash,
+      createdAt: new Date().toISOString(),
+      platform,
+      arch,
+      pythonVersion: versionResult.stdout?.toString().trim()
+    };
+    fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
+    console.log(`\u2705 Bundled Python runtime prepared for ${platform}-${arch}.`);
+  }
+
+  if (fs.existsSync(runtimeDir)) {
+    console.log('\u2139\ufe0f Removing Python bytecode caches from bundled runtime to avoid long paths.');
+    removePythonBytecode(runtimeDir);
+    pruneTorchHeaders(path.join(runtimeDir, 'Lib', 'site-packages'));
+    pruneTorchHeaders(path.join(runtimeDir, 'lib', 'python3.11', 'site-packages'));
+  }
 }
+
+async function main() {
+  if (!fs.existsSync(requirementsPath)) {
+    fail(`Missing requirements file: ${requirementsPath}`);
+  }
+
+  ensureDirectory(resourcesDir);
+
+  if (process.platform === 'win32') {
+    await prepareWindowsEmbeddable();
+    return;
+  }
+
+  const platform = platformMap[process.platform];
+  if (!platform) {
+    fail(`Unsupported platform for bundling Python runtime: ${process.platform}`);
+  }
+
+  const arch = archMap[process.arch];
+  if (!arch) {
+    fail(`Unsupported architecture for bundling Python runtime: ${process.arch}`);
+  }
+
+  preparePosixVirtualEnv(platform, arch);
+}
+
+main().catch(error => {
+  fail('An unexpected error occurred while preparing the Python runtime.', error);
+});

--- a/dbbs-faculty-match/src-tauri/resources/README.txt
+++ b/dbbs-faculty-match/src-tauri/resources/README.txt
@@ -1,3 +1,5 @@
-This directory is packaged with the Tauri bundle. A non-hidden placeholder file is kept
-here so the bundler's glob patterns always match even before the embedded Python runtime
-is generated.
+This directory is packaged with the Tauri bundle. The Windows build stages the CPython
+embeddable distribution here (python.exe, python311.dll, Lib/, DLLs/, site-packages/, and
+app/). Non-Windows builds continue to create platform-specific virtual environments under
+`python/<platform>-<arch>`. A non-hidden placeholder file is kept so the bundler's glob
+patterns always match even before the runtime is generated.


### PR DESCRIPTION
## Summary
- adopt the Windows CPython embeddable distribution in `prepare-python.mjs`, including download handling, site-packages/app staging, and existing virtualenv logic for macOS/Linux
- document the new vendoring flow and add placeholder readmes for the Python app payload and vendored dependencies
- add the `adm-zip` dev dependency so the build can unpack the embeddable archive and clarify how resources are laid out

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e28d582d888325a8e2047af923e798