### PR TITLE
Improve bundled Python runtime resolution

### DIFF
--- a/dbbs-faculty-match/src-tauri/src/lib.rs
+++ b/dbbs-faculty-match/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use std::io::{BufRead, BufReader, Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Instant, SystemTime};
-use tauri::{Emitter, Manager};
+use tauri::{path::BaseDirectory, Emitter, Manager};
 
 const FACULTY_DATASET_BASENAME: &str = "faculty_dataset";
 const FACULTY_DATASET_DEFAULT_EXTENSION: &str = "tsv";
@@ -2985,8 +2985,9 @@ fn bundled_runtime_roots(app_handle: &tauri::AppHandle) -> BundledRuntimeRoots {
     ));
 
     let resolver_root = app_handle
-        .path_resolver()
-        .resolve_resource(runtime_relative.clone());
+        .path()
+        .resolve(&runtime_relative, BaseDirectory::Resource)
+        .ok();
 
     let resource_dir_root = if resolver_root.is_none() {
         app_handle


### PR DESCRIPTION
## Summary
- resolve the bundled Python runtime using the app path resolver before falling back to the resources directory
- centralize bundled runtime root discovery for reuse by the launcher and diagnostics
- expand diagnostics so missing bundles report both attempted runtime roots before trying PATH interpreters

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68e2c2ec72a08325a12a2d92c11fc380