### PR TITLE
Add macOS 13 build targets

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -23,7 +23,9 @@ jobs:
           - os: windows-latest
             artifact-suffix: windows_x64
           - os: macos-latest
-            artifact-suffix: macos
+            artifact-suffix: macos_arm64
+          - os: macos-13
+            artifact-suffix: macos_x64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
@@ -204,7 +206,9 @@ jobs:
           - os: windows-latest
             artifact-suffix: windows_x64
           - os: macos-latest
-            artifact-suffix: macos
+            artifact-suffix: macos_arm64
+          - os: macos-13
+            artifact-suffix: macos_x64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- add macOS 13 to the packaging workflow matrix so both Intel and Apple Silicon builds are produced
- give distinct artifact suffixes for the macOS 13 and macOS latest runners to avoid collisions

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4345e92448325b769c86ae3e8e185