### PR TITLE
Show loading message while embedding helper starts

### DIFF
--- a/dbbs-faculty-match/src/App.tsx
+++ b/dbbs-faculty-match/src/App.tsx
@@ -468,6 +468,12 @@ function App() {
       }
 
       setIsUpdatingEmbeddings(true);
+      setEmbeddingProgress({
+        phase: "initializing",
+        message: "Loading embedding program…",
+        processedRows: 0,
+        totalRows: 0,
+      });
       setEmbeddingStatus(null);
 
       try {


### PR DESCRIPTION
## Summary
- display a loading message when starting a faculty embedding refresh so users know the helper is initializing

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e43b7f6afc8325be1972e9b6e7eb93