### PR TITLE
Work around macOS 13 DMG bundling failure

### DIFF
--- a/dbbs-faculty-match/package.json
+++ b/dbbs-faculty-match/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri",
+    "tauri": "node ./scripts/run-tauri.mjs",
     "build-sidecars": "node ./scripts/build-sidecars.mjs"
   },
   "dependencies": {

--- a/dbbs-faculty-match/scripts/create-dmg.mjs
+++ b/dbbs-faculty-match/scripts/create-dmg.mjs
@@ -1,0 +1,114 @@
+import { mkdtemp, rm, symlink, access, mkdir, unlink, cp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+async function exec(command, args, options = {}) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      ...options,
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function resolveArch() {
+  if (process.env.TAURI_ENV_ARCH) {
+    return process.env.TAURI_ENV_ARCH;
+  }
+
+  switch (process.arch) {
+    case 'arm64':
+      return 'aarch64';
+    case 'x64':
+      return 'x64';
+    default:
+      return process.arch;
+  }
+}
+
+export async function buildDmg({ debug }) {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const rootDir = path.resolve(__dirname, '..');
+  const configPath = path.join(rootDir, 'src-tauri', 'tauri.conf.json');
+  const config = JSON.parse(await readFile(configPath, 'utf8'));
+  const productName = config.productName;
+  const version = config.version;
+
+  const bundleDir = path.join(
+    rootDir,
+    'src-tauri',
+    'target',
+    debug ? 'debug' : 'release',
+    'bundle'
+  );
+
+  const appBundlePath = path.join(bundleDir, 'macos', `${productName}.app`);
+  try {
+    await access(appBundlePath);
+  } catch (error) {
+    console.warn(`Skipping DMG creation because app bundle was not found at ${appBundlePath}`);
+    return;
+  }
+
+  const dmgDir = path.join(bundleDir, 'dmg');
+  await mkdir(dmgDir, { recursive: true });
+
+  const dmgPath = path.join(dmgDir, `${productName}_${version}_${resolveArch()}.dmg`);
+  try {
+    await unlink(dmgPath);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const stagingDir = await mkdtemp(path.join(os.tmpdir(), 'dbbs-faculty-match-dmg-'));
+  const stagedAppPath = path.join(stagingDir, `${productName}.app`);
+  await cp(appBundlePath, stagedAppPath, { recursive: true });
+
+  const applicationsLink = path.join(stagingDir, 'Applications');
+  try {
+    await symlink('/Applications', applicationsLink);
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  }
+
+  const hdiutilArgs = [
+    'create',
+    '-volname',
+    productName,
+    '-fs',
+    'HFS+',
+    '-srcfolder',
+    stagingDir,
+    '-ov',
+    '-format',
+    'UDZO',
+    dmgPath,
+  ];
+
+  console.log('Creating DMG using hdiutil...');
+  try {
+    await exec('hdiutil', hdiutilArgs);
+    console.log(`Created DMG at ${dmgPath}`);
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}

--- a/dbbs-faculty-match/scripts/run-tauri.mjs
+++ b/dbbs-faculty-match/scripts/run-tauri.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const isBuildCommand = args[0] === 'build';
+const isMac = process.platform === 'darwin';
+const forwardedArgs = [...args];
+
+if (
+  isBuildCommand &&
+  isMac &&
+  !forwardedArgs.some((value, index) => value === '--bundles' || value.startsWith('--bundles='))
+) {
+  // Avoid the default DMG bundler which fails on macOS 13 by delegating to our own
+  // post-processing step. We request only the app bundle here and rebuild the DMG later.
+  forwardedArgs.push('--bundles', 'app');
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const tauriExecutable = path.join(
+  __dirname,
+  '..',
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'tauri.cmd' : 'tauri'
+);
+
+const child = spawn(tauriExecutable, forwardedArgs, {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+const [code, signal] = await once(child, 'exit');
+
+if (typeof code === 'number' ? code !== 0 : signal) {
+  process.exit(code ?? 1);
+}
+
+if (isBuildCommand && isMac) {
+  const { buildDmg } = await import('./create-dmg.mjs');
+  await buildDmg({ debug: forwardedArgs.includes('--debug') });
+}


### PR DESCRIPTION
## Summary
- wrap the tauri CLI entrypoint so macOS builds skip the default DMG bundler and run a custom post-build step instead
- add a Node script that recreates the DMG using hdiutil after copying the generated .app bundle into a temporary staging area

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50ed4a77c8325a31447691380553b